### PR TITLE
fix: get message content correctly

### DIFF
--- a/local_llm/__init__.py
+++ b/local_llm/__init__.py
@@ -337,11 +337,11 @@ class LLM:
         if len(messages) > 1:
             for message in messages:
                 if message["role"] == "system":
-                    prompt = f"\nASSISTANT's RULE: {message.content}"
+                    prompt = f"\nASSISTANT's RULE: {message.get('content', '')}"
                 elif message["role"] == "user":
-                    prompt = f"\nUSER: {message.content}"
+                    prompt = f"\nUSER: {message.get('content', '')}"
                 elif message["role"] == "assistant":
-                    prompt = f"\nASSISTANT: {message.content}"
+                    prompt = f"\nASSISTANT: {message.get('content', '')}"
         else:
             try:
                 prompt = messages[0]["content"]


### PR DESCRIPTION
This fixes #3 by getting the message content properly. If for some reason there is no content key it will default to a blank string as to not break due to a KeyError or AttributeError.