### PR TITLE
Add PDF to Audio and Audio to Audio

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,8 @@ RUN git clone https://github.com/Josh-XT/DeepSeek-VL deepseek && \
     cd deepseek && \
     pip install --no-cache-dir -e . && \
     cd ..
+RUN pip install spacy && \
+    python -m spacy download en_core_web_sm
 COPY . .
 ENV HOST 0.0.0.0
 EXPOSE 8091

--- a/Pipes.py
+++ b/Pipes.py
@@ -7,8 +7,6 @@ from ezlocalai.CTTS import CTTS
 from pyngrok import ngrok
 import requests
 import base64
-from pydub import AudioSegment
-import spacy
 import pdfplumber
 from typing import List
 
@@ -75,32 +73,6 @@ class Pipes:
         else:
             self.local_uri = os.environ.get("EZLOCALAI_URL", "http://localhost:8091")
 
-    def chunk_content(self, text: str, chunk_size: int) -> List[str]:
-        try:
-            sp = spacy.load("en_core_web_sm")
-        except:
-            spacy.cli.download("en_core_web_sm")
-            sp = spacy.load("en_core_web_sm")
-        sp.max_length = 99999999999999999999999
-        doc = sp(text)
-        sentences = list(doc.sents)
-        content_chunks = []
-        chunk = []
-        chunk_len = 0
-        for sentence in sentences:
-            sentence_tokens = len(sentence)
-            if chunk_len + sentence_tokens > chunk_size and chunk:
-                chunk_text = " ".join(token.text for token in chunk)
-                content_chunks.append((0, chunk_text))
-                chunk = []
-                chunk_len = 0
-            chunk.extend(sentence)
-            chunk_len += sentence_tokens
-        if chunk:
-            chunk_text = " ".join(token.text for token in chunk)
-            content_chunks.append((0, chunk_text))
-        return [chunk_text for score, chunk_text in content_chunks]
-
     async def pdf_to_audio(self, title, voice, pdf, chunk_size=200):
         filename = f"{title}.pdf"
         file_path = os.path.join(os.getcwd(), "outputs", filename)
@@ -114,22 +86,12 @@ class Pipes:
                 content = "\n".join([page.extract_text() for page in pdf.pages])
         if not content:
             return
-        chunks = self.chunk_content(text=content, chunk_size=chunk_size)
-        title = "".join(char for char in title if char.isalnum())
-        audio_segments = []
-        for i, chunk in enumerate(chunks):
-            await self.ctts.generate(text=chunk, voice=voice, local_uri=self.local_uri)
-            audio_path = os.path.join(os.getcwd(), "outputs", f"{title}_{i}.wav")
-            audio_segments.append(AudioSegment.from_wav(audio_path))
-        combined_audio = AudioSegment.empty()
-        for segment in audio_segments:
-            combined_audio += segment
-        output_path = os.path.join(os.getcwd(), "outputs", f"{title}.wav")
-        combined_audio.export(output_path, format="wav")
-        for i in range(len(chunks)):
-            audio_path = os.path.join(os.getcwd(), "outputs", f"{title}_{i}.wav")
-            os.remove(audio_path)
-        return f"{self.local_uri}/outputs/{title}.wav"
+        return await self.ctts.generate(
+            text=content,
+            voice=voice,
+            local_uri=self.local_uri,
+            output_file_name=f"{title}.wav",
+        )
 
     async def audio_to_audio(self, voice, audio):
         audio_type = audio.split(",")[0].split(":")[1].split(";")[0]

--- a/Pipes.py
+++ b/Pipes.py
@@ -131,6 +131,16 @@ class Pipes:
             os.remove(audio_path)
         return f"{self.local_uri}/outputs/{title}.wav"
 
+    async def audio_to_audio(self, voice, audio):
+        audio_type = audio.split(",")[0].split(":")[1].split(";")[0]
+        audio_format = audio_type.split("/")[1]
+        audio = audio.split(",")[1]
+        audio = base64.b64decode(audio)
+        text = self.stt.transcribe_audio(base64_audio=audio, audio_format=audio_format)
+        return await self.ctts.generate(
+            text=text, voice=voice, local_uri=self.local_uri
+        )
+
     async def get_response(self, data, completion_type="chat"):
         data["local_uri"] = self.local_uri
         images = []

--- a/app.py
+++ b/app.py
@@ -314,6 +314,12 @@ async def text_to_speech(tts: TextToSpeech, user=Depends(verify_api_key)):
                 chunk_size=200,
             )
             return audio
+        if "audio/" in tts.input:
+            audio = await pipe.audio_to_audio(
+                voice=tts.voice,
+                audio=tts.input,
+            )
+            return audio
     audio = await pipe.ctts.generate(
         text=tts.input, voice=tts.voice, language=tts.language
     )

--- a/app.py
+++ b/app.py
@@ -17,6 +17,7 @@ from Pipes import Pipes
 import base64
 import os
 import logging
+import uuid
 from dotenv import load_dotenv
 
 load_dotenv()
@@ -304,6 +305,15 @@ class TextToSpeech(BaseModel):
     dependencies=[Depends(verify_api_key)],
 )
 async def text_to_speech(tts: TextToSpeech, user=Depends(verify_api_key)):
+    if tts.input.startswith("data:"):
+        if "pdf" in tts.input:
+            audio = await pipe.pdf_to_audio(
+                title=tts.user if tts.user else f"{uuid.uuid4().hex}",
+                voice=tts.voice,
+                pdf=tts.input,
+                chunk_size=200,
+            )
+            return audio
     audio = await pipe.ctts.generate(
         text=tts.input, voice=tts.voice, language=tts.language
     )

--- a/ezlocalai/CTTS.py
+++ b/ezlocalai/CTTS.py
@@ -86,15 +86,15 @@ class CTTS:
             sentence_tokens = len(sentence)
             if chunk_len + sentence_tokens > chunk_size and chunk:
                 chunk_text = " ".join(token.text for token in chunk)
-                content_chunks.append((0, chunk_text))
+                content_chunks.append(chunk_text)
                 chunk = []
                 chunk_len = 0
             chunk.extend(sentence)
             chunk_len += sentence_tokens
         if chunk:
             chunk_text = " ".join(token.text for token in chunk)
-            content_chunks.append((0, chunk_text))
-        return [chunk_text for score, chunk_text in content_chunks]
+            content_chunks.append(chunk_text)
+        return [chunk_text for chunk_text in content_chunks]
 
     async def generate(
         self,

--- a/ezlocalai/CTTS.py
+++ b/ezlocalai/CTTS.py
@@ -8,6 +8,9 @@ import requests
 import logging
 from TTS.tts.configs.xtts_config import XttsConfig
 from TTS.tts.models.xtts import Xtts
+from typing import List
+import spacy
+from pydub import AudioSegment
 
 try:
     import deepspeed
@@ -67,14 +70,42 @@ class CTTS:
                 wav_files.append(file.replace(".wav", ""))
         self.voices = wav_files
 
+    def chunk_content(self, text: str, chunk_size: int) -> List[str]:
+        try:
+            sp = spacy.load("en_core_web_sm")
+        except:
+            spacy.cli.download("en_core_web_sm")
+            sp = spacy.load("en_core_web_sm")
+        sp.max_length = 99999999999999999999999
+        doc = sp(text)
+        sentences = list(doc.sents)
+        content_chunks = []
+        chunk = []
+        chunk_len = 0
+        for sentence in sentences:
+            sentence_tokens = len(sentence)
+            if chunk_len + sentence_tokens > chunk_size and chunk:
+                chunk_text = " ".join(token.text for token in chunk)
+                content_chunks.append((0, chunk_text))
+                chunk = []
+                chunk_len = 0
+            chunk.extend(sentence)
+            chunk_len += sentence_tokens
+        if chunk:
+            chunk_text = " ".join(token.text for token in chunk)
+            content_chunks.append((0, chunk_text))
+        return [chunk_text for score, chunk_text in content_chunks]
+
     async def generate(
         self,
         text,
         voice="default",
         language="en",
         local_uri=None,
+        output_file_name=None,
     ):
-        output_file_name = f"{uuid.uuid4().hex}.wav"
+        if not output_file_name:
+            output_file_name = f"{uuid.uuid4().hex}.wav"
         output_file = os.path.join(self.output_folder, output_file_name)
         cleaned_string = re.sub(r"([!?.])\1+", r"\1", text)
         cleaned_string = re.sub(
@@ -95,20 +126,52 @@ class CTTS:
             max_ref_length=self.model.config.max_ref_len,
             sound_norm_refs=self.model.config.sound_norm_refs,
         )
-        output = self.model.inference(
-            text=text,
-            language=language,
-            gpt_cond_latent=gpt_cond_latent,
-            speaker_embedding=speaker_embedding,
-            temperature=0.7,
-            length_penalty=float(self.model.config.length_penalty),
-            repetition_penalty=10.0,
-            top_k=int(self.model.config.top_k),
-            top_p=float(self.model.config.top_p),
-            enable_text_splitting=True,
-        )
-        torchaudio.save(output_file, torch.tensor(output["wav"]).unsqueeze(0), 24000)
-        torch.cuda.empty_cache()
+        if len(text) > 200:
+            text_chunks = self.chunk_content(text, 200)
+            output_files = []
+            for chunk in text_chunks:
+                output = self.model.inference(
+                    text=chunk,
+                    language=language,
+                    gpt_cond_latent=gpt_cond_latent,
+                    speaker_embedding=speaker_embedding,
+                    temperature=0.7,
+                    length_penalty=float(self.model.config.length_penalty),
+                    repetition_penalty=10.0,
+                    top_k=int(self.model.config.top_k),
+                    top_p=float(self.model.config.top_p),
+                    enable_text_splitting=True,
+                )
+                output_file_name = f"{uuid.uuid4().hex}.wav"
+                output_file = os.path.join(self.output_folder, output_file_name)
+                torchaudio.save(
+                    output_file, torch.tensor(output["wav"]).unsqueeze(0), 24000
+                )
+                output_files.append(output_file)
+                torch.cuda.empty_cache()
+            combined_audio = AudioSegment.empty()
+            for file in output_files:
+                audio = AudioSegment.from_file(file)
+                combined_audio += audio
+                os.remove(file)
+            combined_audio.export(output_file, format="wav")
+        else:
+            output = self.model.inference(
+                text=text,
+                language=language,
+                gpt_cond_latent=gpt_cond_latent,
+                speaker_embedding=speaker_embedding,
+                temperature=0.7,
+                length_penalty=float(self.model.config.length_penalty),
+                repetition_penalty=10.0,
+                top_k=int(self.model.config.top_k),
+                top_p=float(self.model.config.top_p),
+                enable_text_splitting=True,
+            )
+            torchaudio.save(
+                output_file, torch.tensor(output["wav"]).unsqueeze(0), 24000
+            )
+            torch.cuda.empty_cache()
         if local_uri:
             return f"{local_uri}/outputs/{output_file_name}"
         with open(output_file, "rb") as file:

--- a/ezlocalai/CTTS.py
+++ b/ezlocalai/CTTS.py
@@ -126,7 +126,7 @@ class CTTS:
             max_ref_length=self.model.config.max_ref_len,
             sound_norm_refs=self.model.config.sound_norm_refs,
         )
-        if len(text) > 200:
+        if len(text) > 700:
             text_chunks = self.chunk_content(text, 200)
             output_files = []
             for chunk in text_chunks:

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,5 @@ accelerate==0.27.2
 python-multipart
 llama-cpp-python==0.2.55
 openai
+pdfplumber
+spacy


### PR DESCRIPTION
Add PDF to Audio and Audio to Audio
- Sending a pdf to the `/v1/audio/speech` endpoint will return audio of the full PDF.
- Sending audio to the `/v1/audio/speech` endpoint will return audio in the voice selected.

```python
import openai

openai.base_url = "http://localhost:8091/v1/"
openai.api_key = "your api key"
pdf_path = "C:\\book.pdf"
with open(pdf_path, "rb") as file:
    base64_encoded_pdf = base64.b64encode(file.read()).decode("utf-8")
base64_output = f"data:application/pdf;base64,{base64_encoded_pdf}"
# If it is an audio file, it would be data:audio/wav;base64,.......
tts_response = openai.audio.speech.create(
    model="tts-1",
    voice="Morgan_Freeman",
    input=base64_output,
    user="Title of audio",
)
# tts_response will be a URL with the audio. Depending on size of PDF, this will take awhile.
print(tts_response)
```

