### PR TITLE
Potential fix for code scanning alert no. 5: Full server-side request forgery

### DIFF
--- a/Pipes.py
+++ b/Pipes.py
@@ -5,6 +5,7 @@ from ezlocalai.LLM import LLM, is_vision_model
 from ezlocalai.STT import STT
 from ezlocalai.CTTS import CTTS
 from ezlocalai.Embedding import Embedding
+from urllib.parse import urlparse
 from pyngrok import ngrok
 import requests
 import base64
@@ -151,9 +152,8 @@ class Pipes:
                             audio_url = audio_url.split(",")[1]
                             audio_format = audio_url.split(";")[0]
                         else:
-                            from urllib.parse import urlparse
                             parsed_url = urlparse(audio_url)
-                            if parsed_url.scheme in ["http", "https"] and parsed_url.netloc.endswith("trusteddomain.com"):
+                            if parsed_url.scheme in ["http", "https"]:
                                 audio_url = requests.get(audio_url).content
                                 audio_url = base64.b64encode(audio_url).decode("utf-8")
                             else:

--- a/Pipes.py
+++ b/Pipes.py
@@ -151,8 +151,13 @@ class Pipes:
                             audio_url = audio_url.split(",")[1]
                             audio_format = audio_url.split(";")[0]
                         else:
-                            audio_url = requests.get(audio_url).content
-                            audio_url = base64.b64encode(audio_url).decode("utf-8")
+                            from urllib.parse import urlparse
+                            parsed_url = urlparse(audio_url)
+                            if parsed_url.scheme in ["http", "https"] and parsed_url.netloc.endswith("trusteddomain.com"):
+                                audio_url = requests.get(audio_url).content
+                                audio_url = base64.b64encode(audio_url).decode("utf-8")
+                            else:
+                                raise ValueError("Invalid audio URL")
                         transcribed_audio = self.stt.transcribe_audio(
                             base64_audio=audio_url, audio_format=audio_format
                         )


### PR DESCRIPTION
Potential fix for [https://github.com/DevXT-LLC/ezlocalai/security/code-scanning/5](https://github.com/DevXT-LLC/ezlocalai/security/code-scanning/5)

To fix the problem, we need to ensure that the `audio_url` is validated before being used in the `requests.get` call. One way to do this is to check that the URL belongs to a trusted domain. This can be done by parsing the URL and verifying its components.

1. Parse the `audio_url` to extract its components.
2. Validate that the URL belongs to a trusted domain.
3. If the URL is valid, proceed with the `requests.get` call; otherwise, handle the invalid URL appropriately.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
