### PR TITLE
feat: Router / Load Balancer mode

### DIFF
--- a/Globals.py
+++ b/Globals.py
@@ -77,6 +77,43 @@ def getenv(var_name: str, default_value: str = None) -> str:
         # Lazy load voice models (TTS/STT) - when false, preload them at startup for faster first response
         # Default true = lazy load (load on first request), false = preload at startup
         "LAZY_LOAD_VOICE": "true",
+        # =====================================================================
+        # Router / Load Balancer mode
+        # =====================================================================
+        # When ROUTER_MODE=true, this instance becomes a pure router:
+        #   - No models are loaded locally
+        #   - Worker ezlocalai instances register themselves and send heartbeats
+        #   - Inference requests are proxied to the best available worker
+        # Use start.py to launch; it auto-selects router_app vs app based on this.
+        "ROUTER_MODE": "false",
+        # Shared secret that workers must present to register/heartbeat with the router.
+        # If empty, EZLOCALAI_API_KEY is used as the shared secret.
+        "ROUTER_REGISTER_KEY": "",
+        # How long (seconds) since last heartbeat before a worker is pruned.
+        "ROUTER_WORKER_TTL": "30",
+        # How long (seconds) the router waits for a worker slot before erroring/queuing.
+        "ROUTER_WAIT_TIMEOUT": "120",
+        # =====================================================================
+        # Worker registration (set on each ezlocalai worker instance)
+        # =====================================================================
+        # If set, this ezlocalai instance will register itself with a router and
+        # heartbeat its current state (free VRAM, queue depth, loaded models).
+        # Example: ROUTER_URL="http://192.168.1.50:8092"
+        "ROUTER_URL": "",
+        # API key/shared secret to authenticate with the router. Falls back to
+        # EZLOCALAI_API_KEY if unset.
+        "ROUTER_API_KEY": "",
+        # Public URL the router should call back on for inference. Defaults to
+        # EZLOCALAI_URL. Override when behind NAT/Cloudflare/ngrok.
+        "WORKER_PUBLIC_URL": "",
+        # Friendly name of this worker (shown in router admin). Defaults to hostname.
+        "WORKER_LABEL": "",
+        # Comma-separated capabilities this worker advertises. Use "auto" to
+        # derive from local config (text/vision/voice/image/video).
+        # Examples: "auto", "text,vision", "voice", "image,video"
+        "WORKER_CAPABILITIES": "auto",
+        # Heartbeat interval in seconds.
+        "WORKER_HEARTBEAT_INTERVAL": "10",
     }
     if not default_value:
         default_value = default_values[var_name] if var_name in default_values else ""

--- a/README.md
+++ b/README.md
@@ -223,6 +223,8 @@ docker compose -f docker-compose-router.yml up -d
 
 The router listens on port `8092` by default and exposes the same OpenAI-compatible endpoints as a normal ezlocalai server, plus:
 
+- `GET  /dashboard`         — live HTML dashboard (auto-refresh, no auth)
+- `GET  /v1/router/dashboard` — same data as JSON (requires client key)
 - `GET  /v1/router/workers` — list registered workers and their live state
 - `GET  /v1/router/health`  — router health + live worker count
 - `POST /v1/router/register` / `heartbeat` / `deregister` — worker protocol

--- a/README.md
+++ b/README.md
@@ -229,25 +229,37 @@ The router listens on port `8092` by default and exposes the same OpenAI-compati
 
 ### Point a worker at the router
 
-On every ezlocalai worker (your 5090 box, your 4090 box, your voice/image boxes, friends' machines, miners), add to its env:
+For most setups, **`ROUTER_URL` is the only env var you need to add** to a worker. The worker self-reports its capabilities, GPUs (model names + VRAM), loaded models, and per-model context windows. The router infers the callback URL from the registration's source IP, so LAN workers don't need `WORKER_PUBLIC_URL`.
+
+Minimum config:
 
 ```bash
 ROUTER_URL=http://router-host:8092
-ROUTER_API_KEY=shared-key             # must match the router's EZLOCALAI_API_KEY (or ROUTER_REGISTER_KEY)
-WORKER_PUBLIC_URL=http://1.2.3.4:8091 # how the router reaches *this* worker (optional, defaults to EZLOCALAI_URL)
-WORKER_LABEL=main-5090                # friendly name (optional)
-WORKER_CAPABILITIES=auto              # or e.g. "text,vision" / "voice" / "image,video"
 ```
+
+Optional overrides:
+
+```bash
+ROUTER_API_KEY=shared-key             # match the router's EZLOCALAI_API_KEY (or ROUTER_REGISTER_KEY)
+WORKER_LABEL=main-5090                # friendly name (defaults to hostname)
+WORKER_CAPABILITIES=auto              # override auto-detect: e.g. "text,vision" / "voice"
+WORKER_PUBLIC_URL=https://gpu1.you.com:8091  # required only when behind NAT/Cloudflare/ngrok
+WORKER_HEARTBEAT_INTERVAL=10          # seconds between heartbeats
+```
+
+> **Behind NAT or a tunnel?** Set `WORKER_PUBLIC_URL` so the router calls back on the public address. Otherwise the router will use the source IP it sees on the registration, which is what you want for LAN workers.
 
 ### Example: your current setup
 
-| Machine               | Address           | Role                             | Env additions                                                                 |
-|-----------------------|-------------------|----------------------------------|-------------------------------------------------------------------------------|
-| Main GPU (5090+3090Ti)| `192.168.1.135:8091` | text/vision (Qwen3.6-35B-A3B)    | `ROUTER_URL=http://192.168.1.50:8092` `WORKER_LABEL=main-5090`                |
-| Fallback GPU (4090)   | `192.168.1.243:8091` | text/vision (Qwen3.6-35B-A3B)    | `ROUTER_URL=...` `WORKER_LABEL=fallback-4090`                                 |
-| Voice server          | `192.168.1.82:8091`  | TTS/STT/wake word                | `ROUTER_URL=...` `WORKER_LABEL=voice` `WORKER_CAPABILITIES=voice`             |
-| Small + image         | `192.168.1.214:8091` | small text + image gen           | `ROUTER_URL=...` `WORKER_LABEL=img-small` `WORKER_CAPABILITIES=text,image`   |
-| Friend's 3090         | external          | text/vision                      | `ROUTER_URL=https://router.you.com:8092` `WORKER_PUBLIC_URL=https://...`     |
+With auto-detection, every worker just needs `ROUTER_URL` (and optionally `WORKER_LABEL`):
+
+| Machine               | Address              | Role                          | Env additions                                                                |
+|-----------------------|----------------------|-------------------------------|------------------------------------------------------------------------------|
+| Main GPU (5090+3090Ti)| `192.168.1.135:8091` | text/vision (Qwen3.6-35B-A3B) | `ROUTER_URL=http://192.168.1.50:8092` `WORKER_LABEL=main-5090`               |
+| Fallback GPU (4090)   | `192.168.1.243:8091` | text/vision (Qwen3.6-35B-A3B) | `ROUTER_URL=...` `WORKER_LABEL=fallback-4090`                                |
+| Voice server          | `192.168.1.82:8091`  | TTS/STT/wake word             | `ROUTER_URL=...` `WORKER_LABEL=voice`                                        |
+| Small + image         | `192.168.1.214:8091` | small text + image gen        | `ROUTER_URL=...` `WORKER_LABEL=img-small`                                    |
+| Friend's 3090         | external             | text/vision                   | `ROUTER_URL=https://router.you.com:8092` `WORKER_PUBLIC_URL=https://gpu.friend.com:8091` |
 
 Clients then point to the router as if it were a single ezlocalai server:
 
@@ -265,14 +277,27 @@ The router will pick the highest-scoring text-capable worker that has the reques
 Workers are scored each request as:
 
 ```
-score = slots_left * 5  +  free_vram_gb  -  in_flight * 2
+score = best_tier * 10  +  slots_left * 5  +  free_vram_gb  -  in_flight * 4
 ```
 
-Where `slots_left = queue_capacity - queue_depth`. Workers without the required capability or model are filtered out before scoring. Stale workers (heartbeat older than TTL) are excluded.
+`best_tier` is derived from the worker's fastest GPU model (e.g. RTX 5090 ≈ 90, RTX 4090 = 80, RTX 3090 = 50, CPU = 1) and dominates the score, so an idle 5090 always beats an idle 3090. The load penalty (`in_flight * 4`) lets a busy 5090 lose to an idle 4090 once it has a few requests in flight, which keeps the pool balanced under burst load.
 
-### Security note
+Workers missing the required capability (`text` / `vision` / `voice` / `image` / `video`) or the requested model are filtered out before scoring. Stale workers (no heartbeat for `ROUTER_WORKER_TTL` seconds) are also excluded.
 
-Workers authenticate to the router with `ROUTER_API_KEY` (falls back to `EZLOCALAI_API_KEY`). Inference clients authenticate with the router's own `EZLOCALAI_API_KEY`. Use distinct keys (`ROUTER_REGISTER_KEY` for workers, `EZLOCALAI_API_KEY` for clients) when exposing the router publicly so you can rotate them independently.
+You can inspect the live registry, including each worker's reported GPUs, tier, free VRAM, queue depth, and per-model context windows:
+
+```bash
+curl https://router.you.com:8092/v1/router/workers \
+  -H "Authorization: Bearer shared-key"
+```
+
+### Open pool vs. authenticated pool
+
+Auth is intentionally simple: there is one shared secret for inference clients (`EZLOCALAI_API_KEY`) and one for workers (`ROUTER_REGISTER_KEY`, which falls back to `EZLOCALAI_API_KEY` if unset).
+
+- **Both empty** → the router runs as an **open pool**: any client can submit requests, any worker can register. This is fine for a closed LAN; it is **not** safe to expose publicly. The router logs a `[Router] OPEN POOL: ...` warning at startup so you don't deploy this by accident.
+- **`EZLOCALAI_API_KEY` set, `ROUTER_REGISTER_KEY` unset** → both clients and workers must present that one key.
+- **Both set, distinct values** → clients use `EZLOCALAI_API_KEY`, workers use `ROUTER_REGISTER_KEY`. Use this when exposing the router publicly so you can rotate the worker secret independently of the client secret.
 
 ## Dedicated Voice Server
 

--- a/README.md
+++ b/README.md
@@ -194,6 +194,86 @@ When fallback is triggered to another ezlocalai instance, these endpoints are au
 
 For OpenAI-compatible APIs, only chat completions and embeddings are forwarded.
 
+## Router / Load Balancer Mode
+
+For setups that outgrow point-to-point fallback (3+ machines, friends contributing GPUs, bittensor miners coming and going), ezlocalai can run as a dedicated **router**. The router itself loads no models — it accepts the normal OpenAI-compatible API and forwards each request to the best registered worker.
+
+### How it works
+
+```
+┌────────────┐  OpenAI API   ┌────────────────────┐   proxied request   ┌─────────────────┐
+│  Client    │ ────────────▶ │  ezlocalai-router  │ ──────────────────▶ │  Worker (5090)  │
+└────────────┘               │   (no models)      │                     ├─────────────────┤
+                             │                    │ ◀── heartbeat ───── │  Worker (4090)  │
+                             │  selects worker    │ ◀── heartbeat ───── │  Worker (voice) │
+                             │  based on free     │ ◀── heartbeat ───── │  Worker (image) │
+                             │  VRAM + queue +    │ ◀── heartbeat ───── │  Friend's 3090  │
+                             │  capability +      │                     └─────────────────┘
+                             │  model availability│
+                             └────────────────────┘
+```
+
+Each worker is a normal `ezlocalai` instance with `ROUTER_URL` set. On startup the worker registers itself, then sends heartbeats every `WORKER_HEARTBEAT_INTERVAL` seconds containing free VRAM, queue depth, loaded models, and advertised capabilities (`text`, `vision`, `voice`, `image`, `video`). Workers that miss `ROUTER_WORKER_TTL` seconds of heartbeats are pruned. If a request arrives and no suitable worker is free, the router waits up to `ROUTER_WAIT_TIMEOUT` seconds before returning `503`.
+
+### Run the router
+
+```bash
+docker compose -f docker-compose-router.yml up -d
+```
+
+The router listens on port `8092` by default and exposes the same OpenAI-compatible endpoints as a normal ezlocalai server, plus:
+
+- `GET  /v1/router/workers` — list registered workers and their live state
+- `GET  /v1/router/health`  — router health + live worker count
+- `POST /v1/router/register` / `heartbeat` / `deregister` — worker protocol
+
+### Point a worker at the router
+
+On every ezlocalai worker (your 5090 box, your 4090 box, your voice/image boxes, friends' machines, miners), add to its env:
+
+```bash
+ROUTER_URL=http://router-host:8092
+ROUTER_API_KEY=shared-key             # must match the router's EZLOCALAI_API_KEY (or ROUTER_REGISTER_KEY)
+WORKER_PUBLIC_URL=http://1.2.3.4:8091 # how the router reaches *this* worker (optional, defaults to EZLOCALAI_URL)
+WORKER_LABEL=main-5090                # friendly name (optional)
+WORKER_CAPABILITIES=auto              # or e.g. "text,vision" / "voice" / "image,video"
+```
+
+### Example: your current setup
+
+| Machine               | Address           | Role                             | Env additions                                                                 |
+|-----------------------|-------------------|----------------------------------|-------------------------------------------------------------------------------|
+| Main GPU (5090+3090Ti)| `192.168.1.135:8091` | text/vision (Qwen3.6-35B-A3B)    | `ROUTER_URL=http://192.168.1.50:8092` `WORKER_LABEL=main-5090`                |
+| Fallback GPU (4090)   | `192.168.1.243:8091` | text/vision (Qwen3.6-35B-A3B)    | `ROUTER_URL=...` `WORKER_LABEL=fallback-4090`                                 |
+| Voice server          | `192.168.1.82:8091`  | TTS/STT/wake word                | `ROUTER_URL=...` `WORKER_LABEL=voice` `WORKER_CAPABILITIES=voice`             |
+| Small + image         | `192.168.1.214:8091` | small text + image gen           | `ROUTER_URL=...` `WORKER_LABEL=img-small` `WORKER_CAPABILITIES=text,image`   |
+| Friend's 3090         | external          | text/vision                      | `ROUTER_URL=https://router.you.com:8092` `WORKER_PUBLIC_URL=https://...`     |
+
+Clients then point to the router as if it were a single ezlocalai server:
+
+```bash
+curl https://router.you.com:8092/v1/chat/completions \
+  -H "Authorization: Bearer shared-key" \
+  -H "Content-Type: application/json" \
+  -d '{"model":"unsloth/Qwen3.6-35B-A3B-GGUF","messages":[{"role":"user","content":"Hi"}]}'
+```
+
+The router will pick the highest-scoring text-capable worker that has the requested model loaded; if none is currently free, it queues until one becomes available (up to `ROUTER_WAIT_TIMEOUT`).
+
+### Selection algorithm
+
+Workers are scored each request as:
+
+```
+score = slots_left * 5  +  free_vram_gb  -  in_flight * 2
+```
+
+Where `slots_left = queue_capacity - queue_depth`. Workers without the required capability or model are filtered out before scoring. Stale workers (heartbeat older than TTL) are excluded.
+
+### Security note
+
+Workers authenticate to the router with `ROUTER_API_KEY` (falls back to `EZLOCALAI_API_KEY`). Inference clients authenticate with the router's own `EZLOCALAI_API_KEY`. Use distinct keys (`ROUTER_REGISTER_KEY` for workers, `EZLOCALAI_API_KEY` for clients) when exposing the router publicly so you can rotate them independently.
+
 ## Dedicated Voice Server
 
 ezlocalai supports offloading TTS (text-to-speech) and STT (speech-to-text) processing to a dedicated voice server. This is useful when you want to:

--- a/Router.py
+++ b/Router.py
@@ -1,0 +1,550 @@
+"""Router/load-balancer support for ezlocalai.
+
+Two pieces live here:
+
+1. ``WorkerRegistry`` + ``Router`` — used by the router process to keep track of
+   worker ezlocalai instances that have registered themselves and to pick the
+   best worker for a given request.
+
+2. ``WorkerHeartbeatClient`` — used by every worker ezlocalai instance to
+   register and heartbeat with a router (when ``ROUTER_URL`` is set).
+
+The router exposes the same OpenAI-compatible API surface as a normal
+ezlocalai server but does no inference itself. It selects a worker based on:
+
+* Capability match (text / vision / voice / image / video / embedding)
+* Whether the worker has the requested model
+* Free VRAM and queue depth (more free, less queued = better score)
+* Liveness (recent heartbeat)
+
+The worker → router protocol is intentionally tiny: a ``register`` on startup,
+periodic ``heartbeat`` POSTs, and a best-effort ``deregister`` on shutdown.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import socket
+import time
+import uuid
+from dataclasses import dataclass, field
+from threading import RLock
+from typing import Any, Dict, List, Optional, Tuple
+
+import aiohttp
+
+from Globals import getenv
+
+
+# ---------------------------------------------------------------------------
+# Capability detection
+# ---------------------------------------------------------------------------
+
+ALL_CAPABILITIES = {"text", "vision", "voice", "image", "video", "embedding"}
+
+
+def detect_local_capabilities() -> List[str]:
+    """Best-effort guess at what this ezlocalai instance can serve.
+
+    Reads the same env vars the rest of the app uses so a worker can advertise
+    itself accurately without manual configuration.
+    """
+    caps: List[str] = []
+    default_model = (getenv("DEFAULT_MODEL") or "").strip()
+    voice_server = (getenv("VOICE_SERVER") or "").strip().lower()
+    image_server = (getenv("IMAGE_SERVER") or "").strip().lower()
+    text_server = (getenv("TEXT_SERVER") or "").strip().lower()
+    img_model = (getenv("IMG_MODEL") or "").strip().lower()
+    video_model = (getenv("VIDEO_MODEL") or "").strip().lower()
+    tts_enabled = (getenv("TTS_ENABLED") or "true").strip().lower() == "true"
+    stt_enabled = (getenv("STT_ENABLED") or "true").strip().lower() == "true"
+
+    # Text/vision: any server that loads an LLM (and isn't dedicated to
+    # voice/image only) can answer text. Vision is detected from common model
+    # name hints — workers can override via WORKER_CAPABILITIES.
+    is_dedicated_voice = voice_server == "true"
+    is_dedicated_image = image_server == "true"
+    if default_model and not (is_dedicated_voice or is_dedicated_image):
+        caps.append("text")
+        lowered = default_model.lower()
+        if any(tag in lowered for tag in ("vl", "vision", "qwen3.6", "qwen3.5-vl")):
+            caps.append("vision")
+    if (
+        (
+            text_server == "true"
+            or (text_server == "" and not is_dedicated_voice and not is_dedicated_image)
+        )
+        and "text" not in caps
+        and default_model
+    ):
+        caps.append("text")
+
+    if tts_enabled or stt_enabled or voice_server == "true":
+        caps.append("voice")
+
+    if (img_model and img_model not in ("none", "")) or image_server == "true":
+        caps.append("image")
+    if video_model and video_model not in ("none", ""):
+        caps.append("video")
+
+    # De-dup, preserve order
+    seen = set()
+    deduped = []
+    for c in caps:
+        if c not in seen:
+            seen.add(c)
+            deduped.append(c)
+    return deduped
+
+
+def parse_capabilities(value: str) -> List[str]:
+    """Parse WORKER_CAPABILITIES env var into a clean list."""
+    value = (value or "").strip()
+    if not value or value.lower() == "auto":
+        return detect_local_capabilities()
+    parts = [p.strip().lower() for p in value.split(",") if p.strip()]
+    return [p for p in parts if p in ALL_CAPABILITIES]
+
+
+# ---------------------------------------------------------------------------
+# Worker registry (router-side)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class WorkerInfo:
+    worker_id: str
+    label: str
+    url: str
+    api_key: str = ""  # Key router should use when calling the worker
+    capabilities: List[str] = field(default_factory=list)
+    models: List[str] = field(default_factory=list)
+    # Live state, updated each heartbeat
+    free_vram_gb: float = 0.0
+    total_vram_gb: float = 0.0
+    free_ram_gb: float = 0.0
+    queue_depth: int = 0
+    queue_capacity: int = 1
+    in_flight: int = 0
+    last_heartbeat: float = field(default_factory=time.time)
+    registered_at: float = field(default_factory=time.time)
+    extra: Dict[str, Any] = field(default_factory=dict)
+
+    def to_public(self) -> Dict[str, Any]:
+        return {
+            "worker_id": self.worker_id,
+            "label": self.label,
+            "url": self.url,
+            "capabilities": list(self.capabilities),
+            "models": list(self.models),
+            "free_vram_gb": self.free_vram_gb,
+            "total_vram_gb": self.total_vram_gb,
+            "free_ram_gb": self.free_ram_gb,
+            "queue_depth": self.queue_depth,
+            "queue_capacity": self.queue_capacity,
+            "in_flight": self.in_flight,
+            "age_seconds": time.time() - self.registered_at,
+            "last_heartbeat_age": time.time() - self.last_heartbeat,
+            "extra": self.extra,
+        }
+
+    def is_alive(self, ttl: float) -> bool:
+        return (time.time() - self.last_heartbeat) <= ttl
+
+    def has_capacity(self) -> bool:
+        # A worker is considered "free" if it has queue room and at least some VRAM
+        return self.queue_depth < max(1, self.queue_capacity)
+
+    def score(self) -> float:
+        """Higher = better worker to send the next request to.
+
+        Prefers: more free VRAM, lower queue utilization, fewer in-flight reqs.
+        """
+        slots_left = max(0, self.queue_capacity - self.queue_depth)
+        vram_score = self.free_vram_gb  # GB
+        load_penalty = self.in_flight * 2.0
+        return slots_left * 5.0 + vram_score - load_penalty
+
+
+class WorkerRegistry:
+    """Thread-safe in-memory registry of worker ezlocalai nodes."""
+
+    def __init__(self, ttl_seconds: float):
+        self._workers: Dict[str, WorkerInfo] = {}
+        self._lock = RLock()
+        self._ttl = ttl_seconds
+
+    @property
+    def ttl(self) -> float:
+        return self._ttl
+
+    def register(self, info: WorkerInfo) -> WorkerInfo:
+        with self._lock:
+            existing = self._workers.get(info.worker_id)
+            if existing:
+                # Preserve registered_at across re-registers
+                info.registered_at = existing.registered_at
+            self._workers[info.worker_id] = info
+            return info
+
+    def heartbeat(
+        self, worker_id: str, payload: Dict[str, Any]
+    ) -> Optional[WorkerInfo]:
+        with self._lock:
+            worker = self._workers.get(worker_id)
+            if worker is None:
+                return None
+            worker.free_vram_gb = float(
+                payload.get("free_vram_gb", worker.free_vram_gb)
+            )
+            worker.total_vram_gb = float(
+                payload.get("total_vram_gb", worker.total_vram_gb)
+            )
+            worker.free_ram_gb = float(payload.get("free_ram_gb", worker.free_ram_gb))
+            worker.queue_depth = int(payload.get("queue_depth", worker.queue_depth))
+            worker.queue_capacity = int(
+                payload.get("queue_capacity", worker.queue_capacity)
+            )
+            worker.in_flight = int(payload.get("in_flight", worker.in_flight))
+            if "models" in payload:
+                worker.models = list(payload["models"])
+            if "capabilities" in payload:
+                worker.capabilities = list(payload["capabilities"])
+            if "extra" in payload and isinstance(payload["extra"], dict):
+                worker.extra.update(payload["extra"])
+            worker.last_heartbeat = time.time()
+            return worker
+
+    def deregister(self, worker_id: str) -> bool:
+        with self._lock:
+            return self._workers.pop(worker_id, None) is not None
+
+    def prune(self) -> List[str]:
+        removed: List[str] = []
+        with self._lock:
+            for wid, w in list(self._workers.items()):
+                if not w.is_alive(self._ttl):
+                    self._workers.pop(wid, None)
+                    removed.append(wid)
+        return removed
+
+    def list_workers(self, alive_only: bool = True) -> List[WorkerInfo]:
+        with self._lock:
+            workers = list(self._workers.values())
+        if alive_only:
+            workers = [w for w in workers if w.is_alive(self._ttl)]
+        return workers
+
+    def increment_in_flight(self, worker_id: str, delta: int = 1) -> None:
+        with self._lock:
+            w = self._workers.get(worker_id)
+            if w is not None:
+                w.in_flight = max(0, w.in_flight + delta)
+
+
+# ---------------------------------------------------------------------------
+# Router (selection logic)
+# ---------------------------------------------------------------------------
+
+
+class Router:
+    def __init__(self, registry: WorkerRegistry):
+        self.registry = registry
+
+    def select_worker(
+        self,
+        capability: str,
+        model: Optional[str] = None,
+    ) -> Optional[WorkerInfo]:
+        """Pick the best worker matching capability + (optionally) model."""
+        candidates = []
+        for worker in self.registry.list_workers(alive_only=True):
+            if capability not in worker.capabilities:
+                continue
+            if model and worker.models and model not in worker.models:
+                # Allow base-name match (strip org prefix)
+                base = model.split("/")[-1].lower()
+                if not any(base in m.lower() for m in worker.models):
+                    continue
+            if not worker.has_capacity():
+                continue
+            candidates.append(worker)
+
+        if not candidates:
+            return None
+        candidates.sort(key=lambda w: w.score(), reverse=True)
+        return candidates[0]
+
+    async def wait_for_worker(
+        self,
+        capability: str,
+        model: Optional[str],
+        timeout: float,
+        poll_interval: float = 0.5,
+    ) -> Optional[WorkerInfo]:
+        """Block up to ``timeout`` seconds waiting for a free worker."""
+        deadline = time.time() + max(0.0, timeout)
+        while True:
+            worker = self.select_worker(capability, model)
+            if worker is not None:
+                return worker
+            if time.time() >= deadline:
+                return None
+            await asyncio.sleep(poll_interval)
+
+
+# ---------------------------------------------------------------------------
+# Worker -> Router heartbeat client
+# ---------------------------------------------------------------------------
+
+
+class WorkerHeartbeatClient:
+    """Background client run on each worker ezlocalai instance.
+
+    Registers with the router on start, sends periodic state updates, and
+    deregisters cleanly on stop.
+    """
+
+    def __init__(
+        self,
+        router_url: str,
+        worker_url: str,
+        api_key: str = "",
+        label: str = "",
+        capabilities: Optional[List[str]] = None,
+        interval: float = 10.0,
+        worker_id: Optional[str] = None,
+    ):
+        self.router_url = router_url.rstrip("/")
+        self.worker_url = worker_url.rstrip("/")
+        self.api_key = api_key
+        self.label = label or socket.gethostname()
+        self.capabilities = capabilities or detect_local_capabilities()
+        self.interval = max(2.0, float(interval))
+        # Stable per-process ID (re-used across reconnects within the process)
+        self.worker_id = worker_id or f"{self.label}-{uuid.uuid4().hex[:8]}"
+        self._task: Optional[asyncio.Task] = None
+        self._stop = asyncio.Event()
+        self._registered = False
+
+    def _headers(self) -> Dict[str, str]:
+        h = {"Content-Type": "application/json"}
+        if self.api_key and self.api_key != "none":
+            h["Authorization"] = f"Bearer {self.api_key}"
+        return h
+
+    async def _gather_state(self) -> Dict[str, Any]:
+        """Snapshot the local server's current state for a heartbeat payload."""
+        free_vram = 0.0
+        total_vram = 0.0
+        free_ram = 0.0
+        models: List[str] = []
+        queue_depth = 0
+        queue_capacity = 1
+        in_flight = 0
+        try:
+            from Pipes import get_resource_manager  # local import: optional dep
+
+            mgr = get_resource_manager()
+            free_vram = float(mgr.get_total_free_vram() or 0.0)
+            total_vram = float(getattr(mgr, "total_vram", 0.0) or 0.0)
+        except Exception as e:  # pragma: no cover - best-effort
+            logging.debug(f"[Heartbeat] resource manager unavailable: {e}")
+        try:
+            import psutil
+
+            free_ram = psutil.virtual_memory().available / (1024**3)
+        except Exception:
+            pass
+        try:
+            # Pull model list from the local Pipes singleton if available
+            from app import pipe  # type: ignore
+
+            data = pipe.get_models() if pipe is not None else {}
+            models = [m.get("id") for m in data.get("data", []) if m.get("id")]
+        except Exception:
+            pass
+        try:
+            from app import request_queue  # type: ignore
+
+            status = request_queue.get_queue_status() if request_queue else {}
+            queue_depth = int(status.get("queue_size", 0)) + int(
+                status.get("processing_count", 0)
+            )
+            queue_capacity = int(status.get("max_concurrent", queue_capacity))
+            in_flight = int(status.get("processing_count", 0))
+        except Exception:
+            pass
+
+        return {
+            "free_vram_gb": free_vram,
+            "total_vram_gb": total_vram,
+            "free_ram_gb": free_ram,
+            "queue_depth": queue_depth,
+            "queue_capacity": queue_capacity,
+            "in_flight": in_flight,
+            "models": models,
+            "capabilities": self.capabilities,
+        }
+
+    async def _post(self, path: str, payload: Dict[str, Any]) -> Tuple[bool, Any]:
+        url = f"{self.router_url}{path}"
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(
+                    url,
+                    json=payload,
+                    headers=self._headers(),
+                    timeout=aiohttp.ClientTimeout(total=10),
+                ) as resp:
+                    if resp.status >= 200 and resp.status < 300:
+                        try:
+                            return True, await resp.json()
+                        except Exception:
+                            return True, None
+                    text = await resp.text()
+                    logging.warning(
+                        f"[Heartbeat] {path} -> HTTP {resp.status}: {text[:200]}"
+                    )
+                    return False, None
+        except Exception as e:
+            logging.debug(f"[Heartbeat] {path} failed: {e}")
+            return False, None
+
+    async def register(self) -> bool:
+        state = await self._gather_state()
+        payload = {
+            "worker_id": self.worker_id,
+            "label": self.label,
+            "url": self.worker_url,
+            "api_key": self.api_key,
+            **state,
+        }
+        ok, _ = await self._post("/v1/router/register", payload)
+        if ok:
+            self._registered = True
+            logging.info(
+                f"[Heartbeat] Registered with router {self.router_url} "
+                f"as {self.label} ({self.worker_id})"
+            )
+        return ok
+
+    async def heartbeat_once(self) -> bool:
+        state = await self._gather_state()
+        payload = {"worker_id": self.worker_id, **state}
+        ok, _ = await self._post("/v1/router/heartbeat", payload)
+        if not ok and self._registered:
+            # Router probably restarted — try to re-register next loop
+            self._registered = False
+        if not self._registered:
+            return await self.register()
+        return ok
+
+    async def deregister(self) -> None:
+        if not self._registered:
+            return
+        await self._post("/v1/router/deregister", {"worker_id": self.worker_id})
+        self._registered = False
+
+    async def _run(self) -> None:
+        # Initial register attempt; retry on failure with backoff
+        backoff = 2.0
+        while not self._stop.is_set():
+            if await self.register():
+                break
+            try:
+                await asyncio.wait_for(self._stop.wait(), timeout=backoff)
+            except asyncio.TimeoutError:
+                pass
+            backoff = min(60.0, backoff * 1.5)
+
+        # Steady-state heartbeats
+        while not self._stop.is_set():
+            try:
+                await self.heartbeat_once()
+            except Exception as e:  # pragma: no cover
+                logging.debug(f"[Heartbeat] loop error: {e}")
+            try:
+                await asyncio.wait_for(self._stop.wait(), timeout=self.interval)
+            except asyncio.TimeoutError:
+                continue
+
+    def start(self) -> None:
+        if self._task and not self._task.done():
+            return
+        self._stop.clear()
+        self._task = asyncio.create_task(self._run())
+
+    async def stop(self) -> None:
+        self._stop.set()
+        if self._task:
+            try:
+                await asyncio.wait_for(self._task, timeout=5.0)
+            except (asyncio.TimeoutError, asyncio.CancelledError):
+                self._task.cancel()
+        try:
+            await self.deregister()
+        except Exception:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Module-level singletons (lazy)
+# ---------------------------------------------------------------------------
+
+_registry: Optional[WorkerRegistry] = None
+_router: Optional[Router] = None
+_heartbeat_client: Optional[WorkerHeartbeatClient] = None
+
+
+def get_registry() -> WorkerRegistry:
+    global _registry
+    if _registry is None:
+        _registry = WorkerRegistry(ttl_seconds=float(getenv("ROUTER_WORKER_TTL", "30")))
+    return _registry
+
+
+def get_router() -> Router:
+    global _router
+    if _router is None:
+        _router = Router(get_registry())
+    return _router
+
+
+def is_router_mode() -> bool:
+    return (getenv("ROUTER_MODE", "false") or "").strip().lower() == "true"
+
+
+def get_heartbeat_client() -> Optional[WorkerHeartbeatClient]:
+    """Build (or return cached) heartbeat client when ROUTER_URL is configured."""
+    global _heartbeat_client
+    if _heartbeat_client is not None:
+        return _heartbeat_client
+    router_url = (getenv("ROUTER_URL") or "").strip()
+    if not router_url:
+        return None
+    if is_router_mode():
+        # A router does not register with itself
+        return None
+    worker_url = (
+        (getenv("WORKER_PUBLIC_URL") or "").strip()
+        or (getenv("EZLOCALAI_URL") or "").strip()
+        or f"http://{socket.gethostname()}:{getenv('PORT', '8091')}"
+    )
+    api_key = (getenv("ROUTER_API_KEY") or "").strip() or (
+        getenv("EZLOCALAI_API_KEY") or ""
+    )
+    label = (getenv("WORKER_LABEL") or "").strip() or socket.gethostname()
+    capabilities = parse_capabilities(getenv("WORKER_CAPABILITIES", "auto"))
+    interval = float(getenv("WORKER_HEARTBEAT_INTERVAL", "10"))
+    _heartbeat_client = WorkerHeartbeatClient(
+        router_url=router_url,
+        worker_url=worker_url,
+        api_key=api_key,
+        label=label,
+        capabilities=capabilities,
+        interval=interval,
+    )
+    return _heartbeat_client

--- a/Router.py
+++ b/Router.py
@@ -109,6 +109,126 @@ def parse_capabilities(value: str) -> List[str]:
 
 
 # ---------------------------------------------------------------------------
+# Hardware tier scoring
+# ---------------------------------------------------------------------------
+# Higher tier = faster inference. Used to break ties when load is similar so
+# requests prefer the 5090 over the 4090 over the 3090, etc. Unrecognized GPUs
+# get TIER_DEFAULT_GPU; CPU-only workers get TIER_CPU.
+# Substring match (case-insensitive) on torch's get_device_name() output.
+GPU_TIERS: List[Tuple[str, int]] = [
+    # Datacenter / Hopper / Blackwell
+    ("h200", 100),
+    ("h100", 95),
+    ("b200", 110),
+    ("a100", 80),
+    ("a6000", 70),
+    ("a40", 65),
+    ("l40", 70),
+    # RTX 50-series (Blackwell)
+    ("5090", 90),
+    ("5080", 75),
+    ("5070 ti", 60),
+    ("5070", 55),
+    ("5060", 40),
+    # RTX 40-series (Ada Lovelace)
+    ("4090", 80),
+    ("4080 super", 65),
+    ("4080", 60),
+    ("4070 ti super", 55),
+    ("4070 ti", 50),
+    ("4070", 45),
+    ("4060 ti", 35),
+    ("4060", 30),
+    # RTX 30-series (Ampere)
+    ("3090 ti", 55),
+    ("3090", 50),
+    ("3080 ti", 45),
+    ("3080", 40),
+    ("3070 ti", 32),
+    ("3070", 30),
+    ("3060 ti", 25),
+    ("3060", 22),
+    # RTX 20-series (Turing)
+    ("2080 ti", 28),
+    ("2080", 22),
+    ("2070", 18),
+    ("2060", 15),
+    # GTX
+    ("1080 ti", 14),
+    ("1080", 12),
+    ("1070", 10),
+    # Jetson
+    ("orin", 18),
+    ("xavier", 8),
+    # AMD
+    ("mi300", 80),
+    ("mi250", 65),
+    ("7900", 50),
+    # Apple Silicon
+    ("m3 max", 35),
+    ("m2 max", 30),
+    ("m1 max", 25),
+    ("m3 ultra", 45),
+    ("m2 ultra", 40),
+]
+TIER_DEFAULT_GPU = 20
+TIER_CPU = 1
+
+
+def gpu_tier_for_name(name: str) -> int:
+    """Look up a hardware tier score from a GPU model name string."""
+    if not name:
+        return TIER_CPU
+    lname = name.lower()
+    for needle, tier in GPU_TIERS:
+        if needle in lname:
+            return tier
+    return TIER_DEFAULT_GPU
+
+
+def detect_local_gpus() -> List[Dict[str, Any]]:
+    """Best-effort enumeration of local CUDA devices with name + total VRAM.
+
+    Returns a list like
+    ``[{"index": 0, "name": "NVIDIA GeForce RTX 5090", "total_vram_gb": 32.0,
+        "tier": 90}, ...]``
+    Empty list when no CUDA is available.
+    """
+    gpus: List[Dict[str, Any]] = []
+    try:
+        import torch  # type: ignore
+
+        if not torch.cuda.is_available():
+            return []
+        for i in range(torch.cuda.device_count()):
+            try:
+                props = torch.cuda.get_device_properties(i)
+                name = props.name
+                total_gb = float(props.total_memory) / (1024**3)
+            except Exception:
+                name = f"cuda:{i}"
+                total_gb = 0.0
+            gpus.append(
+                {
+                    "index": i,
+                    "name": name,
+                    "total_vram_gb": round(total_gb, 2),
+                    "tier": gpu_tier_for_name(name),
+                }
+            )
+    except Exception as e:  # pragma: no cover - best effort
+        logging.debug(f"[Router] GPU enumeration failed: {e}")
+    return gpus
+
+
+def best_gpu_tier(gpus: List[Dict[str, Any]]) -> int:
+    """The fastest GPU's tier on this worker. Falls back to CPU tier."""
+    if not gpus:
+        return TIER_CPU
+    return max(int(g.get("tier", TIER_DEFAULT_GPU)) for g in gpus)
+
+
+# ---------------------------------------------------------------------------
 # Worker registry (router-side)
 # ---------------------------------------------------------------------------
 
@@ -128,6 +248,11 @@ class WorkerInfo:
     queue_depth: int = 0
     queue_capacity: int = 1
     in_flight: int = 0
+    # Hardware introspection (auto-reported by the worker)
+    gpus: List[Dict[str, Any]] = field(default_factory=list)
+    best_tier: int = TIER_CPU
+    # Per-model context window (max_tokens). Auto-reported when available.
+    model_context: Dict[str, int] = field(default_factory=dict)
     last_heartbeat: float = field(default_factory=time.time)
     registered_at: float = field(default_factory=time.time)
     extra: Dict[str, Any] = field(default_factory=dict)
@@ -145,6 +270,9 @@ class WorkerInfo:
             "queue_depth": self.queue_depth,
             "queue_capacity": self.queue_capacity,
             "in_flight": self.in_flight,
+            "gpus": list(self.gpus),
+            "best_tier": self.best_tier,
+            "model_context": dict(self.model_context),
             "age_seconds": time.time() - self.registered_at,
             "last_heartbeat_age": time.time() - self.last_heartbeat,
             "extra": self.extra,
@@ -160,12 +288,23 @@ class WorkerInfo:
     def score(self) -> float:
         """Higher = better worker to send the next request to.
 
-        Prefers: more free VRAM, lower queue utilization, fewer in-flight reqs.
+        Combines:
+          * Hardware tier (5090 > 4090 > 3090 > … > CPU) — dominant factor
+          * Free queue slots
+          * Free VRAM
+          * In-flight load penalty
+
+        Tier dominates so a fast GPU sitting idle always beats a slower one
+        sitting idle, but a heavily loaded fast GPU can lose to an idle slower
+        one because the load penalty grows with in-flight requests.
         """
         slots_left = max(0, self.queue_capacity - self.queue_depth)
-        vram_score = self.free_vram_gb  # GB
-        load_penalty = self.in_flight * 2.0
-        return slots_left * 5.0 + vram_score - load_penalty
+        return (
+            self.best_tier * 10.0
+            + slots_left * 5.0
+            + self.free_vram_gb
+            - self.in_flight * 4.0
+        )
 
 
 class WorkerRegistry:
@@ -212,6 +351,15 @@ class WorkerRegistry:
                 worker.models = list(payload["models"])
             if "capabilities" in payload:
                 worker.capabilities = list(payload["capabilities"])
+            if "gpus" in payload and isinstance(payload["gpus"], list):
+                worker.gpus = list(payload["gpus"])
+                worker.best_tier = best_gpu_tier(worker.gpus)
+            if "model_context" in payload and isinstance(
+                payload["model_context"], dict
+            ):
+                worker.model_context = {
+                    str(k): int(v) for k, v in payload["model_context"].items()
+                }
             if "extra" in payload and isinstance(payload["extra"], dict):
                 worker.extra.update(payload["extra"])
             worker.last_heartbeat = time.time()
@@ -310,19 +458,28 @@ class WorkerHeartbeatClient:
     def __init__(
         self,
         router_url: str,
-        worker_url: str,
+        worker_url: str = "",
         api_key: str = "",
         label: str = "",
         capabilities: Optional[List[str]] = None,
         interval: float = 10.0,
         worker_id: Optional[str] = None,
+        worker_port: Optional[int] = None,
     ):
         self.router_url = router_url.rstrip("/")
-        self.worker_url = worker_url.rstrip("/")
+        self.worker_url = (worker_url or "").rstrip("/")
         self.api_key = api_key
         self.label = label or socket.gethostname()
         self.capabilities = capabilities or detect_local_capabilities()
         self.interval = max(2.0, float(interval))
+        # Port used so the router can build http://<source_ip>:<port> if the
+        # worker did not (or could not) provide a public URL.
+        try:
+            self.worker_port = int(
+                worker_port if worker_port is not None else getenv("PORT", "8091")
+            )
+        except (TypeError, ValueError):
+            self.worker_port = 8091
         # Stable per-process ID (re-used across reconnects within the process)
         self.worker_id = worker_id or f"{self.label}-{uuid.uuid4().hex[:8]}"
         self._task: Optional[asyncio.Task] = None
@@ -344,6 +501,7 @@ class WorkerHeartbeatClient:
         queue_depth = 0
         queue_capacity = 1
         in_flight = 0
+        model_context: Dict[str, int] = {}
         try:
             from Pipes import get_resource_manager  # local import: optional dep
 
@@ -362,8 +520,26 @@ class WorkerHeartbeatClient:
             # Pull model list from the local Pipes singleton if available
             from app import pipe  # type: ignore
 
-            data = pipe.get_models() if pipe is not None else {}
-            models = [m.get("id") for m in data.get("data", []) if m.get("id")]
+            if pipe is not None:
+                data = pipe.get_models()
+                models = [m.get("id") for m in data.get("data", []) if m.get("id")]
+                # Per-model context window from any persistent llm instances.
+                # Falls back to the active llm if persistent_llms is empty.
+                instances = dict(getattr(pipe, "persistent_llms", {}) or {})
+                if not instances and getattr(pipe, "llm", None) is not None:
+                    instances = {getattr(pipe.llm, "model_name", "default"): pipe.llm}
+                for name, inst in instances.items():
+                    n_ctx = 0
+                    xlc = getattr(inst, "xlc_params", None)
+                    if xlc is not None and getattr(xlc, "n_ctx", 0):
+                        n_ctx = int(xlc.n_ctx)
+                    elif hasattr(inst, "n_ctx"):
+                        try:
+                            n_ctx = int(inst.n_ctx)
+                        except Exception:
+                            n_ctx = 0
+                    if n_ctx > 0:
+                        model_context[str(name)] = n_ctx
         except Exception:
             pass
         try:
@@ -378,6 +554,7 @@ class WorkerHeartbeatClient:
         except Exception:
             pass
 
+        gpus = detect_local_gpus()
         return {
             "free_vram_gb": free_vram,
             "total_vram_gb": total_vram,
@@ -387,6 +564,9 @@ class WorkerHeartbeatClient:
             "in_flight": in_flight,
             "models": models,
             "capabilities": self.capabilities,
+            "gpus": gpus,
+            "best_tier": best_gpu_tier(gpus),
+            "model_context": model_context,
         }
 
     async def _post(self, path: str, payload: Dict[str, Any]) -> Tuple[bool, Any]:
@@ -419,6 +599,7 @@ class WorkerHeartbeatClient:
             "worker_id": self.worker_id,
             "label": self.label,
             "url": self.worker_url,
+            "port": self.worker_port,
             "api_key": self.api_key,
             **state,
         }
@@ -528,11 +709,11 @@ def get_heartbeat_client() -> Optional[WorkerHeartbeatClient]:
     if is_router_mode():
         # A router does not register with itself
         return None
-    worker_url = (
-        (getenv("WORKER_PUBLIC_URL") or "").strip()
-        or (getenv("EZLOCALAI_URL") or "").strip()
-        or f"http://{socket.gethostname()}:{getenv('PORT', '8091')}"
-    )
+    worker_url = (getenv("WORKER_PUBLIC_URL") or "").strip() or (
+        getenv("EZLOCALAI_URL") or ""
+    ).strip()
+    # If still empty, leave it empty so the router substitutes the connection's
+    # source IP (works automatically for LAN workers behind no NAT).
     api_key = (getenv("ROUTER_API_KEY") or "").strip() or (
         getenv("EZLOCALAI_API_KEY") or ""
     )

--- a/app.py
+++ b/app.py
@@ -134,6 +134,19 @@ app.add_middleware(
 async def startup_event():
     await request_queue.start()
 
+    # Start router heartbeat client if ROUTER_URL is configured
+    try:
+        from Router import get_heartbeat_client
+
+        hb = get_heartbeat_client()
+        if hb is not None:
+            hb.start()
+            logging.info(
+                f"[Heartbeat] Worker registration loop started for router {hb.router_url}"
+            )
+    except Exception as e:
+        logging.warning(f"[Heartbeat] Failed to start worker heartbeat: {e}")
+
     # Initialize wake word manager in voice server mode
     from Pipes import is_voice_server_mode
 
@@ -176,6 +189,15 @@ async def startup_event():
 @app.on_event("shutdown")
 async def shutdown_event():
     await request_queue.stop()
+    # Best-effort deregister from router
+    try:
+        from Router import get_heartbeat_client
+
+        hb = get_heartbeat_client()
+        if hb is not None:
+            await hb.stop()
+    except Exception as e:
+        logging.debug(f"[Heartbeat] shutdown error: {e}")
 
 
 # Async wrapper for pipe.get_response

--- a/docker-compose-cuda.yml
+++ b/docker-compose-cuda.yml
@@ -29,6 +29,13 @@ services:
       - TEXT_SERVER_API_KEY=${TEXT_SERVER_API_KEY:-}
       - LAZY_LOAD_VOICE=${LAZY_LOAD_VOICE:-false}
       - TTS_PROVIDER=${TTS_PROVIDER:-chatterbox}
+      # Optional: register with a router/load balancer
+      - ROUTER_URL=${ROUTER_URL:-}
+      - ROUTER_API_KEY=${ROUTER_API_KEY:-}
+      - WORKER_PUBLIC_URL=${WORKER_PUBLIC_URL:-}
+      - WORKER_LABEL=${WORKER_LABEL:-}
+      - WORKER_CAPABILITIES=${WORKER_CAPABILITIES:-auto}
+      - WORKER_HEARTBEAT_INTERVAL=${WORKER_HEARTBEAT_INTERVAL:-10}
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "curl", "-sf", "http://localhost:8091/health"]

--- a/docker-compose-router.yml
+++ b/docker-compose-router.yml
@@ -1,0 +1,31 @@
+services:
+  ezlocalai-router:
+    container_name: ezlocalai-router
+    image: joshxt/ezlocalai:latest
+    environment:
+      - ROUTER_MODE=true
+      - EZLOCALAI_API_KEY=${EZLOCALAI_API_KEY-}
+      # Optional: distinct shared secret workers must present.
+      # Defaults to EZLOCALAI_API_KEY when empty.
+      - ROUTER_REGISTER_KEY=${ROUTER_REGISTER_KEY-}
+      # How long since the last heartbeat before a worker is considered dead.
+      - ROUTER_WORKER_TTL=${ROUTER_WORKER_TTL-30}
+      # How long the router waits for a free worker before returning 503.
+      - ROUTER_WAIT_TIMEOUT=${ROUTER_WAIT_TIMEOUT-120}
+      - LOG_LEVEL=${LOG_LEVEL-INFO}
+      - HOST=0.0.0.0
+      - PORT=8092
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost:8092/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+    logging:
+      driver: json-file
+      options:
+        max-size: "100m"
+        max-file: "3"
+    ports:
+      - "8092:8092"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,9 +20,13 @@ services:
       - TEXT_SERVER=${TEXT_SERVER-}
       - TEXT_SERVER_API_KEY=${TEXT_SERVER_API_KEY-}
       - LAZY_LOAD_VOICE=${LAZY_LOAD_VOICE-true}
-      # Optional: register with a router/load balancer
+      # Router mode — set ROUTER_MODE=true to run as a load-balancer instead of a worker
+      - ROUTER_MODE=${ROUTER_MODE-false}
+      - ROUTER_REGISTER_KEY=${ROUTER_REGISTER_KEY-}
+      - ROUTER_WORKER_TTL=${ROUTER_WORKER_TTL-30}
+      - ROUTER_WAIT_TIMEOUT=${ROUTER_WAIT_TIMEOUT-120}
+      # Optional: register with an upstream router/load balancer
       - ROUTER_URL=${ROUTER_URL-}
-      - ROUTER_API_KEY=${ROUTER_API_KEY-}
       - WORKER_PUBLIC_URL=${WORKER_PUBLIC_URL-}
       - WORKER_LABEL=${WORKER_LABEL-}
       - WORKER_CAPABILITIES=${WORKER_CAPABILITIES-auto}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,13 @@ services:
       - TEXT_SERVER=${TEXT_SERVER-}
       - TEXT_SERVER_API_KEY=${TEXT_SERVER_API_KEY-}
       - LAZY_LOAD_VOICE=${LAZY_LOAD_VOICE-true}
+      # Optional: register with a router/load balancer
+      - ROUTER_URL=${ROUTER_URL-}
+      - ROUTER_API_KEY=${ROUTER_API_KEY-}
+      - WORKER_PUBLIC_URL=${WORKER_PUBLIC_URL-}
+      - WORKER_LABEL=${WORKER_LABEL-}
+      - WORKER_CAPABILITIES=${WORKER_CAPABILITIES-auto}
+      - WORKER_HEARTBEAT_INTERVAL=${WORKER_HEARTBEAT_INTERVAL-10}
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "curl", "-sf", "http://localhost:8091/health"]

--- a/router_app.py
+++ b/router_app.py
@@ -1,0 +1,568 @@
+"""Router-mode FastAPI app for ezlocalai.
+
+This app does **no** local inference. It accepts the same OpenAI-compatible
+endpoints as a normal ezlocalai server and proxies each request to the best
+available worker that has registered itself via the router protocol.
+
+Run with::
+
+    ROUTER_MODE=true python start.py
+
+(or set ``ROUTER_MODE=true`` in your env / docker-compose service.)
+
+Endpoints exposed:
+
+Router protocol
+    * ``POST /v1/router/register``     — worker registration
+    * ``POST /v1/router/heartbeat``    — periodic state update
+    * ``POST /v1/router/deregister``   — graceful shutdown
+    * ``GET  /v1/router/workers``      — admin: list registered workers
+    * ``GET  /v1/router/health``       — router health (always reports queue ok)
+
+OpenAI-compatible (proxied)
+    * ``GET  /v1/models``
+    * ``POST /v1/chat/completions``    (streaming + non-streaming)
+    * ``POST /v1/completions``         (streaming + non-streaming)
+    * ``POST /v1/embeddings``
+    * ``POST /v1/audio/speech``
+    * ``POST /v1/audio/speech/stream``
+    * ``POST /v1/audio/transcriptions``
+    * ``GET  /v1/audio/voices``
+    * ``POST /v1/images/generations``
+    * ``POST /v1/images/edits``
+    * ``POST /v1/videos/generations``
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import time
+from typing import Any, Dict, List, Optional
+
+import aiohttp
+from fastapi import (
+    Depends,
+    FastAPI,
+    File,
+    Form,
+    Header,
+    HTTPException,
+    Request,
+    UploadFile,
+)
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse, Response, StreamingResponse
+
+from Globals import getenv
+from Router import (
+    Router,
+    WorkerInfo,
+    WorkerRegistry,
+    get_registry,
+    get_router,
+)
+
+
+logging.basicConfig(
+    level=getenv("LOG_LEVEL"),
+    format=getenv("LOG_FORMAT"),
+    force=True,
+)
+
+
+app = FastAPI(title="ezlocalai Router", docs_url="/")
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+# ---------------------------------------------------------------------------
+# Auth helpers
+# ---------------------------------------------------------------------------
+
+
+def _expected_register_key() -> str:
+    """Shared secret that workers must present to register/heartbeat."""
+    return (getenv("ROUTER_REGISTER_KEY") or "").strip() or (
+        getenv("EZLOCALAI_API_KEY") or ""
+    ).strip()
+
+
+def _expected_client_key() -> str:
+    """API key that inference clients must present (same as a normal ezlocalai)."""
+    return (getenv("EZLOCALAI_API_KEY") or "").strip()
+
+
+def _check_bearer(authorization: Optional[str], expected: str) -> None:
+    if not expected or expected == "none":
+        return  # auth disabled
+    if not authorization:
+        raise HTTPException(status_code=401, detail="Missing Authorization header")
+    parts = authorization.split(None, 1)
+    token = parts[1].strip() if len(parts) == 2 else parts[0].strip()
+    if token != expected:
+        raise HTTPException(status_code=401, detail="Invalid API key")
+
+
+def verify_client(authorization: Optional[str] = Header(None)) -> str:
+    _check_bearer(authorization, _expected_client_key())
+    return "USER"
+
+
+def verify_worker(authorization: Optional[str] = Header(None)) -> str:
+    _check_bearer(authorization, _expected_register_key())
+    return "WORKER"
+
+
+# ---------------------------------------------------------------------------
+# Background pruner
+# ---------------------------------------------------------------------------
+
+
+_pruner_task: Optional[asyncio.Task] = None
+
+
+async def _pruner_loop():
+    registry = get_registry()
+    while True:
+        try:
+            removed = registry.prune()
+            for wid in removed:
+                logging.info(f"[Router] Pruned stale worker {wid}")
+        except Exception as e:  # pragma: no cover
+            logging.debug(f"[Router] pruner error: {e}")
+        await asyncio.sleep(max(2.0, registry.ttl / 3))
+
+
+@app.on_event("startup")
+async def _startup():
+    global _pruner_task
+    if _pruner_task is None or _pruner_task.done():
+        _pruner_task = asyncio.create_task(_pruner_loop())
+    logging.info(f"[Router] ezlocalai router ready (worker TTL={get_registry().ttl}s)")
+
+
+@app.on_event("shutdown")
+async def _shutdown():
+    global _pruner_task
+    if _pruner_task and not _pruner_task.done():
+        _pruner_task.cancel()
+        try:
+            await _pruner_task
+        except (asyncio.CancelledError, Exception):
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Router protocol endpoints (workers ↔ router)
+# ---------------------------------------------------------------------------
+
+
+@app.post("/v1/router/register", tags=["Router"])
+async def router_register(payload: Dict[str, Any], _: str = Depends(verify_worker)):
+    required = ("worker_id", "url")
+    for key in required:
+        if not payload.get(key):
+            raise HTTPException(status_code=400, detail=f"Missing field: {key}")
+    info = WorkerInfo(
+        worker_id=str(payload["worker_id"]),
+        label=str(payload.get("label") or payload["worker_id"]),
+        url=str(payload["url"]).rstrip("/"),
+        api_key=str(payload.get("api_key") or ""),
+        capabilities=list(payload.get("capabilities") or []),
+        models=list(payload.get("models") or []),
+        free_vram_gb=float(payload.get("free_vram_gb", 0.0) or 0.0),
+        total_vram_gb=float(payload.get("total_vram_gb", 0.0) or 0.0),
+        free_ram_gb=float(payload.get("free_ram_gb", 0.0) or 0.0),
+        queue_depth=int(payload.get("queue_depth", 0) or 0),
+        queue_capacity=int(payload.get("queue_capacity", 1) or 1),
+        in_flight=int(payload.get("in_flight", 0) or 0),
+        extra={
+            k: v
+            for k, v in payload.items()
+            if k
+            not in {
+                "worker_id",
+                "label",
+                "url",
+                "api_key",
+                "capabilities",
+                "models",
+                "free_vram_gb",
+                "total_vram_gb",
+                "free_ram_gb",
+                "queue_depth",
+                "queue_capacity",
+                "in_flight",
+            }
+        },
+    )
+    info = get_registry().register(info)
+    logging.info(
+        f"[Router] Registered worker {info.label} ({info.worker_id}) "
+        f"@ {info.url} caps={info.capabilities}"
+    )
+    return {"ok": True, "worker": info.to_public()}
+
+
+@app.post("/v1/router/heartbeat", tags=["Router"])
+async def router_heartbeat(payload: Dict[str, Any], _: str = Depends(verify_worker)):
+    worker_id = payload.get("worker_id")
+    if not worker_id:
+        raise HTTPException(status_code=400, detail="Missing worker_id")
+    worker = get_registry().heartbeat(str(worker_id), payload)
+    if worker is None:
+        # Tell caller to re-register
+        return JSONResponse(
+            status_code=410,
+            content={
+                "ok": False,
+                "reason": "unknown_worker",
+                "should_reregister": True,
+            },
+        )
+    return {"ok": True, "worker": worker.to_public()}
+
+
+@app.post("/v1/router/deregister", tags=["Router"])
+async def router_deregister(payload: Dict[str, Any], _: str = Depends(verify_worker)):
+    worker_id = payload.get("worker_id")
+    if not worker_id:
+        raise HTTPException(status_code=400, detail="Missing worker_id")
+    removed = get_registry().deregister(str(worker_id))
+    return {"ok": removed}
+
+
+@app.get("/v1/router/workers", tags=["Router"])
+async def router_workers(_: str = Depends(verify_client)):
+    workers = get_registry().list_workers(alive_only=False)
+    return {
+        "object": "list",
+        "data": [w.to_public() for w in workers],
+        "ttl_seconds": get_registry().ttl,
+    }
+
+
+@app.get("/v1/router/health", tags=["Router"])
+async def router_health():
+    workers = get_registry().list_workers(alive_only=True)
+    return {
+        "status": "healthy",
+        "alive_workers": len(workers),
+        "ttl_seconds": get_registry().ttl,
+    }
+
+
+@app.get("/health", tags=["System"])
+async def health():
+    return {"status": "healthy"}
+
+
+# ---------------------------------------------------------------------------
+# Worker selection helpers
+# ---------------------------------------------------------------------------
+
+
+def _wait_timeout() -> float:
+    return float(getenv("ROUTER_WAIT_TIMEOUT", "120"))
+
+
+async def _pick(capability: str, model: Optional[str] = None) -> WorkerInfo:
+    router = get_router()
+    worker = await router.wait_for_worker(capability, model, timeout=_wait_timeout())
+    if worker is None:
+        raise HTTPException(
+            status_code=503,
+            detail=(
+                f"No worker available for capability={capability!r}"
+                + (f" model={model!r}" if model else "")
+            ),
+        )
+    return worker
+
+
+def _worker_headers(worker: WorkerInfo) -> Dict[str, str]:
+    h = {}
+    if worker.api_key and worker.api_key != "none":
+        h["Authorization"] = f"Bearer {worker.api_key}"
+    return h
+
+
+# ---------------------------------------------------------------------------
+# Generic proxy helpers
+# ---------------------------------------------------------------------------
+
+
+async def _proxy_json(
+    worker: WorkerInfo,
+    path: str,
+    payload: Dict[str, Any],
+    *,
+    stream: bool = False,
+    timeout: Optional[float] = None,
+):
+    """Forward a JSON POST to a worker. Returns either a dict or a StreamingResponse."""
+    url = f"{worker.url}{path}"
+    headers = {"Content-Type": "application/json", **_worker_headers(worker)}
+    request_timeout = aiohttp.ClientTimeout(
+        total=timeout or float(getenv("REQUEST_TIMEOUT", "300"))
+    )
+    registry = get_registry()
+    registry.increment_in_flight(worker.worker_id, 1)
+
+    if not stream:
+        try:
+            async with aiohttp.ClientSession(timeout=request_timeout) as session:
+                async with session.post(url, json=payload, headers=headers) as resp:
+                    body = await resp.read()
+                    media_type = resp.headers.get("Content-Type", "application/json")
+                    return Response(
+                        content=body, status_code=resp.status, media_type=media_type
+                    )
+        finally:
+            registry.increment_in_flight(worker.worker_id, -1)
+
+    async def gen():
+        # Open one persistent session for the whole stream
+        session = aiohttp.ClientSession(timeout=request_timeout)
+        try:
+            resp = await session.post(url, json=payload, headers=headers)
+            try:
+                async for chunk in resp.content.iter_any():
+                    if chunk:
+                        yield chunk
+            finally:
+                resp.release()
+        except Exception as e:
+            logging.warning(f"[Router] Stream from {worker.url}{path} failed: {e}")
+        finally:
+            await session.close()
+            registry.increment_in_flight(worker.worker_id, -1)
+
+    return StreamingResponse(gen(), media_type="text/event-stream")
+
+
+async def _proxy_get(worker: WorkerInfo, path: str) -> Response:
+    url = f"{worker.url}{path}"
+    headers = _worker_headers(worker)
+    request_timeout = aiohttp.ClientTimeout(total=30)
+    async with aiohttp.ClientSession(timeout=request_timeout) as session:
+        async with session.get(url, headers=headers) as resp:
+            body = await resp.read()
+            media_type = resp.headers.get("Content-Type", "application/json")
+            return Response(
+                content=body, status_code=resp.status, media_type=media_type
+            )
+
+
+async def _proxy_multipart(
+    worker: WorkerInfo,
+    path: str,
+    *,
+    files: Dict[str, tuple],
+    fields: Dict[str, str],
+    timeout: Optional[float] = None,
+) -> Response:
+    """Forward a multipart/form-data POST to a worker.
+
+    ``files`` is ``{field_name: (filename, content_bytes, content_type)}``.
+    """
+    url = f"{worker.url}{path}"
+    headers = _worker_headers(worker)
+    request_timeout = aiohttp.ClientTimeout(
+        total=timeout or float(getenv("REQUEST_TIMEOUT", "300"))
+    )
+    registry = get_registry()
+    registry.increment_in_flight(worker.worker_id, 1)
+    try:
+        data = aiohttp.FormData()
+        for name, (fname, content, ctype) in files.items():
+            data.add_field(name, content, filename=fname, content_type=ctype)
+        for k, v in fields.items():
+            if v is not None:
+                data.add_field(k, str(v))
+        async with aiohttp.ClientSession(timeout=request_timeout) as session:
+            async with session.post(url, data=data, headers=headers) as resp:
+                body = await resp.read()
+                media_type = resp.headers.get("Content-Type", "application/json")
+                return Response(
+                    content=body, status_code=resp.status, media_type=media_type
+                )
+    finally:
+        registry.increment_in_flight(worker.worker_id, -1)
+
+
+# ---------------------------------------------------------------------------
+# OpenAI-compatible proxy endpoints
+# ---------------------------------------------------------------------------
+
+
+@app.get("/v1/models", tags=["Models"])
+async def models(_: str = Depends(verify_client)):
+    """Aggregate model list across all live workers."""
+    seen: Dict[str, Dict[str, Any]] = {}
+    for w in get_registry().list_workers(alive_only=True):
+        for m in w.models:
+            seen.setdefault(
+                m, {"id": m, "object": "model", "owned_by": "ezlocalai", "workers": []}
+            )["workers"].append(w.label)
+    return {"object": "list", "data": list(seen.values())}
+
+
+@app.post("/v1/chat/completions", tags=["Chat"])
+async def chat_completions(payload: Dict[str, Any], _: str = Depends(verify_client)):
+    model = payload.get("model")
+    # Vision detection: any message with image_url content -> vision
+    needs_vision = False
+    for msg in payload.get("messages", []) or []:
+        content = msg.get("content")
+        if isinstance(content, list):
+            for part in content:
+                if isinstance(part, dict) and part.get("type") in (
+                    "image_url",
+                    "input_image",
+                ):
+                    needs_vision = True
+                    break
+        if needs_vision:
+            break
+    capability = "vision" if needs_vision else "text"
+    worker = await _pick(capability, model)
+    return await _proxy_json(
+        worker,
+        "/v1/chat/completions",
+        payload,
+        stream=bool(payload.get("stream")),
+    )
+
+
+@app.post("/v1/completions", tags=["Completions"])
+async def completions(payload: Dict[str, Any], _: str = Depends(verify_client)):
+    worker = await _pick("text", payload.get("model"))
+    return await _proxy_json(
+        worker, "/v1/completions", payload, stream=bool(payload.get("stream"))
+    )
+
+
+@app.post("/v1/embeddings", tags=["Embeddings"])
+async def embeddings(payload: Dict[str, Any], _: str = Depends(verify_client)):
+    # Embeddings count as text capability for now (most ezlocalai workers serve both)
+    worker = (
+        await _pick("embedding", payload.get("model"))
+        if any("embedding" in w.capabilities for w in get_registry().list_workers())
+        else await _pick("text", payload.get("model"))
+    )
+    return await _proxy_json(worker, "/v1/embeddings", payload, stream=False)
+
+
+@app.post("/v1/audio/speech", tags=["Audio"])
+async def audio_speech(payload: Dict[str, Any], _: str = Depends(verify_client)):
+    worker = await _pick("voice", payload.get("model"))
+    return await _proxy_json(worker, "/v1/audio/speech", payload, stream=False)
+
+
+@app.post("/v1/audio/speech/stream", tags=["Audio"])
+async def audio_speech_stream(payload: Dict[str, Any], _: str = Depends(verify_client)):
+    worker = await _pick("voice", payload.get("model"))
+    return await _proxy_json(worker, "/v1/audio/speech/stream", payload, stream=True)
+
+
+@app.get("/v1/audio/voices", tags=["Audio"])
+async def audio_voices(_: str = Depends(verify_client)):
+    # Aggregate voices from any voice-capable worker
+    voices: List[Dict[str, Any]] = []
+    seen = set()
+    for w in get_registry().list_workers(alive_only=True):
+        if "voice" not in w.capabilities:
+            continue
+        try:
+            resp = await _proxy_get(w, "/v1/audio/voices")
+            data = json.loads(resp.body) if resp.body else {}
+            for v in data.get("voices", []) or data.get("data", []) or []:
+                key = v.get("id") if isinstance(v, dict) else v
+                if key not in seen:
+                    seen.add(key)
+                    voices.append(v)
+        except Exception as e:
+            logging.debug(f"[Router] voices from {w.url} failed: {e}")
+    return {"voices": voices}
+
+
+@app.post("/v1/audio/transcriptions", tags=["Audio"])
+async def audio_transcriptions(
+    file: UploadFile = File(...),
+    model: Optional[str] = Form(None),
+    language: Optional[str] = Form(None),
+    prompt: Optional[str] = Form(None),
+    response_format: Optional[str] = Form("json"),
+    temperature: Optional[float] = Form(0.0),
+    timestamps: Optional[bool] = Form(None),
+    _: str = Depends(verify_client),
+):
+    worker = await _pick("voice", model)
+    content = await file.read()
+    return await _proxy_multipart(
+        worker,
+        "/v1/audio/transcriptions",
+        files={
+            "file": (
+                file.filename or "audio.wav",
+                content,
+                file.content_type or "audio/wav",
+            )
+        },
+        fields={
+            "model": model,
+            "language": language,
+            "prompt": prompt,
+            "response_format": response_format,
+            "temperature": temperature,
+            "timestamps": timestamps,
+        },
+    )
+
+
+@app.post("/v1/images/generations", tags=["Images"])
+async def images_generations(payload: Dict[str, Any], _: str = Depends(verify_client)):
+    worker = await _pick("image", payload.get("model"))
+    return await _proxy_json(worker, "/v1/images/generations", payload, stream=False)
+
+
+@app.post("/v1/images/edits", tags=["Images"])
+async def images_edits(request: Request, _: str = Depends(verify_client)):
+    """Image edits use multipart; forward all parts as-is."""
+    form = await request.form()
+    files: Dict[str, tuple] = {}
+    fields: Dict[str, str] = {}
+    for key, value in form.multi_items():
+        if hasattr(value, "read"):
+            content = await value.read()
+            files[key] = (
+                getattr(value, "filename", None) or "file",
+                content,
+                getattr(value, "content_type", None) or "application/octet-stream",
+            )
+        else:
+            fields[key] = str(value)
+    worker = await _pick("image", fields.get("model"))
+    return await _proxy_multipart(
+        worker, "/v1/images/edits", files=files, fields=fields
+    )
+
+
+@app.post("/v1/videos/generations", tags=["Videos"])
+async def videos_generations(payload: Dict[str, Any], _: str = Depends(verify_client)):
+    worker = await _pick("video", payload.get("model"))
+    return await _proxy_json(
+        worker,
+        "/v1/videos/generations",
+        payload,
+        stream=False,
+        timeout=float(getenv("REQUEST_TIMEOUT", "1800")),
+    )

--- a/router_app.py
+++ b/router_app.py
@@ -60,6 +60,7 @@ from Router import (
     Router,
     WorkerInfo,
     WorkerRegistry,
+    best_gpu_tier,
     get_registry,
     get_router,
 )
@@ -145,6 +146,22 @@ async def _startup():
     global _pruner_task
     if _pruner_task is None or _pruner_task.done():
         _pruner_task = asyncio.create_task(_pruner_loop())
+    register_key = _expected_register_key()
+    client_key = _expected_client_key()
+    auth_warnings = []
+    if not register_key or register_key == "none":
+        auth_warnings.append(
+            "ROUTER_REGISTER_KEY/EZLOCALAI_API_KEY is empty — ANY worker that "
+            "can reach this router can join the pool. Set EZLOCALAI_API_KEY (or "
+            "ROUTER_REGISTER_KEY) before exposing the router publicly."
+        )
+    if not client_key or client_key == "none":
+        auth_warnings.append(
+            "EZLOCALAI_API_KEY is empty — ANY client can submit inference "
+            "requests to the router."
+        )
+    for msg in auth_warnings:
+        logging.warning(f"[Router] OPEN POOL: {msg}")
     logging.info(f"[Router] ezlocalai router ready (worker TTL={get_registry().ttl}s)")
 
 
@@ -165,15 +182,48 @@ async def _shutdown():
 
 
 @app.post("/v1/router/register", tags=["Router"])
-async def router_register(payload: Dict[str, Any], _: str = Depends(verify_worker)):
-    required = ("worker_id", "url")
-    for key in required:
-        if not payload.get(key):
-            raise HTTPException(status_code=400, detail=f"Missing field: {key}")
+async def router_register(
+    request: Request,
+    payload: Dict[str, Any],
+    _: str = Depends(verify_worker),
+):
+    if not payload.get("worker_id"):
+        raise HTTPException(status_code=400, detail="Missing field: worker_id")
+
+    # Resolve a URL the router can call back on. Order:
+    # 1. Whatever the worker explicitly reported (if non-loopback).
+    # 2. http://<source-IP>:<reported port> (router fills in the source IP).
+    # 3. Reject — the worker is unreachable.
+    declared_url = str(payload.get("url") or "").strip().rstrip("/")
+    port = int(payload.get("port") or 8091)
+    source_host = request.client.host if request.client else None
+
+    def _is_loopback(u: str) -> bool:
+        u = u.lower()
+        return (
+            "://localhost" in u
+            or "://127.0.0.1" in u
+            or "://0.0.0.0" in u
+            or "://::1" in u
+        )
+
+    url = declared_url
+    if not url or _is_loopback(url):
+        if not source_host:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "Worker did not provide a public 'url' and the router "
+                    "could not determine the source IP."
+                ),
+            )
+        url = f"http://{source_host}:{port}"
+
+    gpus = list(payload.get("gpus") or [])
     info = WorkerInfo(
         worker_id=str(payload["worker_id"]),
         label=str(payload.get("label") or payload["worker_id"]),
-        url=str(payload["url"]).rstrip("/"),
+        url=url,
         api_key=str(payload.get("api_key") or ""),
         capabilities=list(payload.get("capabilities") or []),
         models=list(payload.get("models") or []),
@@ -183,6 +233,11 @@ async def router_register(payload: Dict[str, Any], _: str = Depends(verify_worke
         queue_depth=int(payload.get("queue_depth", 0) or 0),
         queue_capacity=int(payload.get("queue_capacity", 1) or 1),
         in_flight=int(payload.get("in_flight", 0) or 0),
+        gpus=gpus,
+        best_tier=int(payload.get("best_tier") or best_gpu_tier(gpus)),
+        model_context={
+            str(k): int(v) for k, v in (payload.get("model_context") or {}).items()
+        },
         extra={
             k: v
             for k, v in payload.items()
@@ -191,6 +246,7 @@ async def router_register(payload: Dict[str, Any], _: str = Depends(verify_worke
                 "worker_id",
                 "label",
                 "url",
+                "port",
                 "api_key",
                 "capabilities",
                 "models",
@@ -200,13 +256,24 @@ async def router_register(payload: Dict[str, Any], _: str = Depends(verify_worke
                 "queue_depth",
                 "queue_capacity",
                 "in_flight",
+                "gpus",
+                "best_tier",
+                "model_context",
             }
         },
     )
     info = get_registry().register(info)
+    gpu_summary = (
+        ", ".join(
+            f"{g.get('name', '?')} ({g.get('total_vram_gb', 0):.0f}GB)"
+            for g in info.gpus
+        )
+        or "no GPU"
+    )
     logging.info(
         f"[Router] Registered worker {info.label} ({info.worker_id}) "
-        f"@ {info.url} caps={info.capabilities}"
+        f"@ {info.url} caps={info.capabilities} tier={info.best_tier} "
+        f"gpus=[{gpu_summary}]"
     )
     return {"ok": True, "worker": info.to_public()}
 

--- a/router_app.py
+++ b/router_app.py
@@ -53,7 +53,7 @@ from fastapi import (
     UploadFile,
 )
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import JSONResponse, Response, StreamingResponse
+from fastapi.responses import HTMLResponse, JSONResponse, Response, StreamingResponse
 
 from Globals import getenv
 from Router import (
@@ -329,6 +329,333 @@ async def router_health():
 @app.get("/health", tags=["System"])
 async def health():
     return {"status": "healthy"}
+
+
+# ---------------------------------------------------------------------------
+# Dashboard
+# ---------------------------------------------------------------------------
+
+
+def _aggregate_dashboard() -> Dict[str, Any]:
+    """Build a JSON-serialisable summary of the entire pool."""
+    registry = get_registry()
+    alive = registry.list_workers(alive_only=True)
+    stale = [w for w in registry.list_workers(alive_only=False) if w not in alive]
+
+    total_capacity = sum(max(1, w.queue_capacity) for w in alive)
+    total_in_flight = sum(max(0, w.in_flight) for w in alive)
+    total_queue_depth = sum(max(0, w.queue_depth) for w in alive)
+    total_slots_left = sum(max(0, w.queue_capacity - w.queue_depth) for w in alive)
+    total_free_vram = sum(w.free_vram_gb for w in alive)
+    total_vram = sum(w.total_vram_gb for w in alive)
+
+    # Per-model rollup: which workers serve it, total parallel slots, max ctx
+    model_rollup: Dict[str, Dict[str, Any]] = {}
+    for w in alive:
+        slots_left = max(0, w.queue_capacity - w.queue_depth)
+        for model in w.models:
+            entry = model_rollup.setdefault(
+                model,
+                {
+                    "model": model,
+                    "worker_count": 0,
+                    "total_capacity": 0,
+                    "available_slots": 0,
+                    "max_context": 0,
+                    "best_tier": 0,
+                    "workers": [],
+                },
+            )
+            entry["worker_count"] += 1
+            entry["total_capacity"] += max(1, w.queue_capacity)
+            entry["available_slots"] += slots_left
+            ctx = int(w.model_context.get(model, 0) or 0)
+            if ctx > entry["max_context"]:
+                entry["max_context"] = ctx
+            if w.best_tier > entry["best_tier"]:
+                entry["best_tier"] = w.best_tier
+            entry["workers"].append(
+                {
+                    "label": w.label,
+                    "worker_id": w.worker_id,
+                    "best_tier": w.best_tier,
+                    "context": ctx,
+                    "slots_left": slots_left,
+                    "queue_capacity": w.queue_capacity,
+                }
+            )
+
+    # Per-capability rollup
+    cap_rollup: Dict[str, Dict[str, Any]] = {}
+    for w in alive:
+        slots_left = max(0, w.queue_capacity - w.queue_depth)
+        for cap in w.capabilities:
+            entry = cap_rollup.setdefault(
+                cap,
+                {
+                    "capability": cap,
+                    "worker_count": 0,
+                    "total_capacity": 0,
+                    "available_slots": 0,
+                },
+            )
+            entry["worker_count"] += 1
+            entry["total_capacity"] += max(1, w.queue_capacity)
+            entry["available_slots"] += slots_left
+
+    return {
+        "generated_at": time.time(),
+        "router": {
+            "register_key_set": bool(_expected_register_key()),
+            "client_key_set": bool(_expected_client_key()),
+            "open_pool": not _expected_register_key(),
+            "ttl_seconds": registry.ttl,
+            "wait_timeout": _wait_timeout(),
+        },
+        "totals": {
+            "alive_workers": len(alive),
+            "stale_workers": len(stale),
+            "total_parallel_capacity": total_capacity,
+            "total_in_flight": total_in_flight,
+            "total_queue_depth": total_queue_depth,
+            "total_available_slots": total_slots_left,
+            "total_free_vram_gb": round(total_free_vram, 2),
+            "total_vram_gb": round(total_vram, 2),
+            "unique_models": len(model_rollup),
+        },
+        "capabilities": sorted(cap_rollup.values(), key=lambda x: x["capability"]),
+        "models": sorted(
+            model_rollup.values(),
+            key=lambda x: (-x["best_tier"], x["model"]),
+        ),
+        "workers": [w.to_public() for w in alive]
+        + [{**w.to_public(), "stale": True} for w in stale],
+    }
+
+
+@app.get("/v1/router/dashboard", tags=["Router"])
+async def router_dashboard_json(_: str = Depends(verify_client)):
+    """JSON form of the dashboard data."""
+    return _aggregate_dashboard()
+
+
+def _render_dashboard_html(data: Dict[str, Any]) -> str:
+    totals = data["totals"]
+    router_meta = data["router"]
+    open_pool_banner = (
+        '<div class="banner warn">⚠ OPEN POOL — anyone reachable can register '
+        "as a worker. Set <code>ROUTER_REGISTER_KEY</code> for production.</div>"
+        if router_meta["open_pool"]
+        else ""
+    )
+
+    # Capability cards
+    cap_cards = (
+        "".join(
+            f"""
+        <div class="card cap">
+          <div class="cap-name">{c['capability']}</div>
+          <div class="cap-stats">
+            <span><b>{c['worker_count']}</b> workers</span>
+            <span><b>{c['available_slots']}</b>/{c['total_capacity']} slots free</span>
+          </div>
+        </div>
+        """
+            for c in data["capabilities"]
+        )
+        or '<div class="muted">No capabilities advertised yet.</div>'
+    )
+
+    # Model rows
+    def _model_row(m: Dict[str, Any]) -> str:
+        worker_pills = "".join(
+            f'<span class="pill" title="tier {w["best_tier"]} · {w["slots_left"]}/{w["queue_capacity"]} slots free · ctx {w["context"] or "?"}">'
+            f'{w["label"]}</span>'
+            for w in m["workers"]
+        )
+        ctx = f"{m['max_context']:,}" if m["max_context"] else "?"
+        return f"""
+        <tr>
+          <td class="mono">{m['model']}</td>
+          <td class="num">{m['worker_count']}</td>
+          <td class="num">{m['total_capacity']}</td>
+          <td class="num">{m['available_slots']}</td>
+          <td class="num">{ctx}</td>
+          <td class="num">{m['best_tier']}</td>
+          <td>{worker_pills}</td>
+        </tr>
+        """
+
+    model_rows = "".join(_model_row(m) for m in data["models"]) or (
+        '<tr><td colspan="7" class="muted">No models loaded across the pool.</td></tr>'
+    )
+
+    # Worker rows
+    def _worker_row(w: Dict[str, Any]) -> str:
+        stale = w.get("stale")
+        gpus = (
+            ", ".join(
+                f"{g.get('name', '?')} ({g.get('total_vram_gb', 0):.0f}GB)"
+                for g in w.get("gpus", [])
+            )
+            or "—"
+        )
+        models = ", ".join(w.get("models") or []) or "—"
+        slots_left = max(
+            0, int(w.get("queue_capacity", 1)) - int(w.get("queue_depth", 0))
+        )
+        slots_total = int(w.get("queue_capacity", 1))
+        slot_pct = 0 if slots_total == 0 else (1 - slots_left / slots_total) * 100
+        bar = f'<div class="bar"><div class="bar-fill" style="width:{slot_pct:.0f}%"></div></div>'
+        ctx_summary = (
+            ", ".join(
+                f"{name}={ctx:,}"
+                for name, ctx in (w.get("model_context") or {}).items()
+            )
+            or "—"
+        )
+        last_hb = w.get("last_heartbeat_age", 0)
+        status = "🔴 stale" if stale else ("🟢 ready" if slots_left > 0 else "🟡 full")
+        return f"""
+        <tr class="{'stale' if stale else ''}">
+          <td><b>{w['label']}</b><div class="muted small">{w['worker_id']}</div></td>
+          <td>{status}</td>
+          <td class="mono small">{w['url']}</td>
+          <td>{gpus}<div class="muted small">tier {w.get('best_tier', 0)}</div></td>
+          <td class="num">{w.get('free_vram_gb', 0):.1f}/{w.get('total_vram_gb', 0):.0f} GB</td>
+          <td>{slots_left}/{slots_total} {bar}<div class="muted small">{w.get('in_flight', 0)} in flight</div></td>
+          <td class="small">{', '.join(w.get('capabilities') or []) or '—'}</td>
+          <td class="small mono">{models}</td>
+          <td class="small mono">{ctx_summary}</td>
+          <td class="num small">{last_hb:.0f}s</td>
+        </tr>
+        """
+
+    worker_rows = "".join(_worker_row(w) for w in data["workers"]) or (
+        '<tr><td colspan="10" class="muted">No workers registered.</td></tr>'
+    )
+
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>ezlocalai Router</title>
+<meta http-equiv="refresh" content="5" />
+<style>
+  :root {{
+    --bg: #0f1419; --fg: #e6edf3; --muted: #8b949e; --card: #161b22;
+    --border: #30363d; --accent: #58a6ff; --warn: #f0883e; --ok: #3fb950;
+  }}
+  * {{ box-sizing: border-box; }}
+  body {{ background: var(--bg); color: var(--fg); font: 14px/1.45 -apple-system,
+         BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif; margin: 0;
+         padding: 24px; }}
+  h1 {{ margin: 0 0 4px; font-size: 22px; }}
+  h2 {{ margin: 32px 0 12px; font-size: 16px; color: var(--muted);
+        text-transform: uppercase; letter-spacing: 0.05em; }}
+  .muted {{ color: var(--muted); }}
+  .small {{ font-size: 12px; }}
+  .mono {{ font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }}
+  code {{ background: rgba(110,118,129,0.2); padding: 1px 6px; border-radius: 4px; }}
+  .banner {{ padding: 10px 14px; border-radius: 6px; margin-bottom: 16px; }}
+  .banner.warn {{ background: rgba(240,136,62,0.15); border: 1px solid var(--warn); }}
+  .grid {{ display: grid; grid-template-columns: repeat(auto-fit, minmax(180px,1fr));
+           gap: 12px; }}
+  .card {{ background: var(--card); border: 1px solid var(--border);
+           border-radius: 8px; padding: 14px 16px; }}
+  .stat .label {{ color: var(--muted); font-size: 11px; text-transform: uppercase;
+                  letter-spacing: 0.05em; }}
+  .stat .value {{ font-size: 24px; font-weight: 600; margin-top: 4px; }}
+  .stat .sub {{ color: var(--muted); font-size: 12px; margin-top: 2px; }}
+  .cap .cap-name {{ font-weight: 600; text-transform: capitalize; }}
+  .cap .cap-stats {{ display: flex; gap: 14px; margin-top: 6px;
+                     color: var(--muted); font-size: 12px; }}
+  table {{ width: 100%; border-collapse: collapse; background: var(--card);
+           border: 1px solid var(--border); border-radius: 8px; overflow: hidden; }}
+  th, td {{ padding: 10px 12px; text-align: left; border-bottom: 1px solid var(--border); }}
+  th {{ background: rgba(110,118,129,0.1); font-size: 11px; text-transform: uppercase;
+        letter-spacing: 0.05em; color: var(--muted); }}
+  tr:last-child td {{ border-bottom: none; }}
+  tr.stale {{ opacity: 0.55; }}
+  td.num, th.num {{ text-align: right; font-variant-numeric: tabular-nums; }}
+  .pill {{ display: inline-block; padding: 2px 8px; margin: 2px;
+           border-radius: 999px; background: rgba(88,166,255,0.15);
+           border: 1px solid rgba(88,166,255,0.4); font-size: 11px; }}
+  .bar {{ display: inline-block; width: 80px; height: 6px; margin-left: 6px;
+          background: rgba(110,118,129,0.25); border-radius: 3px;
+          vertical-align: middle; overflow: hidden; }}
+  .bar-fill {{ height: 100%; background: linear-gradient(90deg, var(--ok), var(--warn)); }}
+  .header {{ display: flex; justify-content: space-between; align-items: baseline;
+             flex-wrap: wrap; gap: 12px; }}
+  .header .meta {{ color: var(--muted); font-size: 12px; }}
+</style>
+</head>
+<body>
+  <div class="header">
+    <div>
+      <h1>ezlocalai router</h1>
+      <div class="meta">TTL {router_meta['ttl_seconds']:.0f}s · wait timeout {router_meta['wait_timeout']:.0f}s
+      · auto-refresh 5s</div>
+    </div>
+    <div class="meta">register key: {'set' if router_meta['register_key_set'] else 'unset'}
+      · client key: {'set' if router_meta['client_key_set'] else 'unset'}</div>
+  </div>
+
+  {open_pool_banner}
+
+  <div class="grid">
+    <div class="card stat"><div class="label">Workers</div>
+      <div class="value">{totals['alive_workers']}</div>
+      <div class="sub">{totals['stale_workers']} stale</div></div>
+    <div class="card stat"><div class="label">Parallel capacity</div>
+      <div class="value">{totals['total_parallel_capacity']}</div>
+      <div class="sub">{totals['total_available_slots']} slots free now</div></div>
+    <div class="card stat"><div class="label">In flight</div>
+      <div class="value">{totals['total_in_flight']}</div>
+      <div class="sub">{totals['total_queue_depth']} queued</div></div>
+    <div class="card stat"><div class="label">Free VRAM</div>
+      <div class="value">{totals['total_free_vram_gb']:.0f} GB</div>
+      <div class="sub">of {totals['total_vram_gb']:.0f} GB total</div></div>
+    <div class="card stat"><div class="label">Unique models</div>
+      <div class="value">{totals['unique_models']}</div>
+      <div class="sub">across the pool</div></div>
+  </div>
+
+  <h2>Capabilities</h2>
+  <div class="grid">{cap_cards}</div>
+
+  <h2>Models</h2>
+  <table>
+    <thead><tr>
+      <th>Model</th><th class="num">Workers</th><th class="num">Total parallel</th>
+      <th class="num">Available now</th><th class="num">Max context</th>
+      <th class="num">Best tier</th><th>Hosted by</th>
+    </tr></thead>
+    <tbody>{model_rows}</tbody>
+  </table>
+
+  <h2>Workers</h2>
+  <table>
+    <thead><tr>
+      <th>Label</th><th>Status</th><th>URL</th><th>GPUs</th>
+      <th>Free VRAM</th><th>Slots free</th><th>Capabilities</th>
+      <th>Models</th><th>Context (per model)</th><th class="num">Last hb</th>
+    </tr></thead>
+    <tbody>{worker_rows}</tbody>
+  </table>
+</body>
+</html>"""
+
+
+@app.get("/dashboard", tags=["Router"], response_class=HTMLResponse)
+async def router_dashboard():
+    """Human-friendly HTML dashboard. Auto-refreshes every 5 seconds.
+
+    Intentionally unauthenticated so the router operator can drop it on a
+    private network without juggling browser auth — gate it at the reverse
+    proxy layer if you expose the router publicly.
+    """
+    return HTMLResponse(_render_dashboard_html(_aggregate_dashboard()))
 
 
 # ---------------------------------------------------------------------------

--- a/start.py
+++ b/start.py
@@ -19,13 +19,21 @@ warnings.filterwarnings("ignore", category=SyntaxWarning)
 
 
 def main():
-    # Run precache first (quietly - it has its own logging)
-    precache_result = subprocess.run(
-        [sys.executable, "precache.py"], cwd=os.path.dirname(os.path.abspath(__file__))
-    )
+    router_mode = (os.getenv("ROUTER_MODE", "false") or "").strip().lower() == "true"
 
-    if precache_result.returncode != 0:
-        print("[ezlocalai] Warning: Precache had errors, continuing anyway...")
+    if router_mode:
+        # Router has no models to precache and uses a separate FastAPI app
+        print("[ezlocalai] Starting in ROUTER mode (no local models)")
+        app_target = "router_app:app"
+    else:
+        # Run precache first (quietly - it has its own logging)
+        precache_result = subprocess.run(
+            [sys.executable, "precache.py"],
+            cwd=os.path.dirname(os.path.abspath(__file__)),
+        )
+        if precache_result.returncode != 0:
+            print("[ezlocalai] Warning: Precache had errors, continuing anyway...")
+        app_target = "app:app"
 
     # Get worker count from environment
     workers = os.getenv("UVICORN_WORKERS", "1")
@@ -37,7 +45,7 @@ def main():
         sys.executable,
         "-m",
         "uvicorn",
-        "app:app",
+        app_target,
         "--host",
         host,
         "--port",


### PR DESCRIPTION
## Overview

Adds a dedicated **router/load-balancer mode** to ezlocalai. A router instance loads no models — it accepts the standard OpenAI-compatible API and dispatches each request to the best available worker node.

## Architecture

```
Client ──► ezlocalai-router (ROUTER_MODE=true, port 8092)
              │  selects worker by: capability + model + score
              │  score = slots_left*5 + free_vram_gb − in_flight*2
              ▼
   [ Worker A (5090) | Worker B (4090) | Worker C (voice) | Worker D (image) | Friend's 3090 ]
              ▲           ▲                  ▲                   ▲                  ▲
              └───────────┴──────────────────┴───────────────────┴──────────────────┘
                                    heartbeats every WORKER_HEARTBEAT_INTERVAL s
```

Workers register on startup and send periodic heartbeats carrying live state (free VRAM, queue depth, loaded models, capabilities). Stale workers are pruned after `ROUTER_WORKER_TTL` seconds. If no suitable worker is available the router queues the request up to `ROUTER_WAIT_TIMEOUT` seconds before returning 503.

## New files

| File | Purpose |
|------|---------|
| `Router.py` | `WorkerRegistry`, `Router` (selection), `WorkerHeartbeatClient` (worker-side) |
| `router_app.py` | FastAPI app — OpenAI-compatible proxy + router protocol endpoints |
| `docker-compose-router.yml` | Spin up a router container (no GPU needed) |

## Changed files

- **`Globals.py`** — new env vars: `ROUTER_MODE`, `ROUTER_REGISTER_KEY`, `ROUTER_WORKER_TTL`, `ROUTER_WAIT_TIMEOUT`, `ROUTER_URL`, `ROUTER_API_KEY`, `WORKER_PUBLIC_URL`, `WORKER_LABEL`, `WORKER_CAPABILITIES`, `WORKER_HEARTBEAT_INTERVAL`
- **`app.py`** — startup/shutdown hooks launch `WorkerHeartbeatClient` when `ROUTER_URL` is set
- **`start.py`** — detects `ROUTER_MODE=true` → launches `router_app` (no precache run)
- **`docker-compose.yml`** / **`docker-compose-cuda.yml`** — pass-through new worker env vars
- **`README.md`** — new *Router / Load Balancer Mode* section with diagram, example setup table, and scoring docs

## Quick start

**Router** (one machine, no GPU needed):
```bash
docker compose -f docker-compose-router.yml up -d
```

**Each worker** — add to its env:
```bash
ROUTER_URL=http://router-host:8092
ROUTER_API_KEY=shared-key
WORKER_LABEL=main-5090          # optional friendly name
WORKER_CAPABILITIES=auto        # auto-detects text/vision/voice/image/video
```

## Router protocol endpoints

- `POST /v1/router/register` — worker registration
- `POST /v1/router/heartbeat` — periodic state update
- `POST /v1/router/deregister` — graceful shutdown
- `GET  /v1/router/workers` — admin: live worker list
- `GET  /v1/router/health` — router health + worker count

## Testing

Smoke-tested in-process with a fake uvicorn worker:
- ✅ Register / heartbeat / deregister round-trip (unknown worker → 410 + `should_reregister`)
- ✅ Capability auto-detection from env vars
- ✅ Aggregated `/v1/models` across registered workers
- ✅ Non-streaming and streaming chat completion proxy
- ✅ Binary audio speech proxy (correct `audio/wav` content-type preserved)
- ✅ Capability mismatch → queues → 503 after `ROUTER_WAIT_TIMEOUT`