### PR TITLE
fix: update python-dotenv to 1.2.2 to address GHSA-mf9w-mj56-hr94

### DIFF
--- a/cuda-requirements.txt
+++ b/cuda-requirements.txt
@@ -3,7 +3,7 @@ uvicorn
 pydantic
 requests==2.33.0
 tiktoken==0.7.0
-python-dotenv==1.0.1
+python-dotenv==1.2.2
 beautifulsoup4==4.12.3
 faster-whisper==1.2.0
 gguf

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ requests==2.33.0
 aiohttp
 psutil
 tiktoken==0.6.0
-python-dotenv==1.0.1
+python-dotenv==1.2.2
 beautifulsoup4==4.12.3
 faster-whisper==1.0.3
 pydub==0.25.1

--- a/rocm-requirements.txt
+++ b/rocm-requirements.txt
@@ -3,7 +3,7 @@ uvicorn
 pydantic
 requests==2.33.0
 tiktoken==0.7.0
-python-dotenv==1.0.1
+python-dotenv==1.2.2
 beautifulsoup4==4.12.3
 faster-whisper==1.2.0
 gguf

--- a/rpi-requirements.txt
+++ b/rpi-requirements.txt
@@ -7,7 +7,7 @@ pydantic
 requests==2.33.0
 aiohttp
 tiktoken==0.6.0
-python-dotenv==1.0.1
+python-dotenv==1.2.2
 beautifulsoup4==4.12.3
 pydub==0.25.1
 ffmpeg-python==0.2.0


### PR DESCRIPTION
## Summary

Update python-dotenv from 1.0.1 to 1.2.2 across all requirements files to address the symlink following vulnerability (GHSA-mf9w-mj56-hr94 / CVE-2026-28684).

## Plan executed

- Updated python-dotenv to 1.2.2 in:
  - `rpi-requirements.txt`
  - `rocm-requirements.txt`
  - `requirements.txt`
  - `cuda-requirements.txt`

## Verification

- Verified all 4 files now contain `python-dotenv==1.2.2`
- Git diff confirms 4 files changed with 4 insertions and 4 deletions

## Notes / follow-ups

- Security advisory GHSA-mf9w-mj56-hr94 should be closed after merge