### PR TITLE
feat: update xllamacpp to 2026.6.9713 across all Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN pip install chatterbox-tts --no-deps --no-cache-dir
 RUN pip install esp-ppq --no-deps --no-cache-dir
 
 # Install xllamacpp CPU version
-RUN pip install xllamacpp==2026.6.9538 --force-reinstall --no-cache-dir
+RUN pip install xllamacpp==2026.6.9713 --force-reinstall --no-cache-dir
 
 COPY . .
 ENV HOST=0.0.0.0 \

--- a/cuda.Dockerfile
+++ b/cuda.Dockerfile
@@ -46,7 +46,7 @@ ENV HOST=0.0.0.0 \
     HF_HOME=/app/models \
     HF_HUB_CACHE=/app/models
 # Install xllamacpp with CUDA 12.8 support (compatible with CUDA 12.9)
-RUN uv pip install xllamacpp==2026.6.9538 --reinstall --index-url https://xorbitsai.github.io/xllamacpp/whl/cu128
+RUN uv pip install xllamacpp==2026.6.9713 --reinstall --index-url https://xorbitsai.github.io/xllamacpp/whl/cu128
 COPY . .
 EXPOSE 8091
 # Use start.py which runs precache once, then starts uvicorn workers

--- a/jetson.Dockerfile
+++ b/jetson.Dockerfile
@@ -93,7 +93,7 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && \
 ENV PATH="/root/.cargo/bin:${PATH}"
 
 ARG CUDA_ARCH=87
-ARG XLLAMACPP_SOURCE_REF=v2026.6.9538-cu128
+ARG XLLAMACPP_SOURCE_REF=v2026.6.9713-cu128
 ENV XLLAMACPP_BUILD_CUDA=1 \
     CMAKE_CUDA_ARCHITECTURES=${CUDA_ARCH} \
     CMAKE_BUILD_PARALLEL_LEVEL=4 \

--- a/rocm.Dockerfile
+++ b/rocm.Dockerfile
@@ -38,7 +38,7 @@ ENV HOST=0.0.0.0 \
     HF_HOME=/app/models \
     HF_HUB_CACHE=/app/models
 # Install xllamacpp with ROCm 6.4.1 support
-RUN uv pip install xllamacpp==2026.6.9538 --reinstall --index-url https://xorbitsai.github.io/xllamacpp/whl/rocm-6.4.1
+RUN uv pip install xllamacpp==2026.6.9713 --reinstall --index-url https://xorbitsai.github.io/xllamacpp/whl/rocm-6.4.1
 COPY . .
 EXPOSE 8091
 # Use start.py which runs precache once, then starts uvicorn workers

--- a/rpi.Dockerfile
+++ b/rpi.Dockerfile
@@ -24,7 +24,7 @@ RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
     python3 -m pip install --no-cache-dir -r rpi-requirements.txt
 
 # Install xllamacpp - prebuilt aarch64 wheels available on PyPI
-RUN pip install xllamacpp==2026.6.9538 --force-reinstall --no-cache-dir
+RUN pip install xllamacpp==2026.6.9713 --force-reinstall --no-cache-dir
 
 COPY . .
 


### PR DESCRIPTION
## Summary
Update xllamacpp from version 2026.6.9538 to the latest release 2026.6.9713 across all ezLocalai Dockerfiles.

## Plan Executed
- [x] Update CPU Dockerfile (Dockerfile): pip install xllamacpp==2026.6.9713
- [x] Update CUDA Dockerfile (cuda.Dockerfile): uv pip install with cu128 index URL
- [x] Update ROCm Dockerfile (rocm.Dockerfile): uv pip install with rocm-6.4.1 index URL
- [x] Update Jetson Dockerfile (jetson.Dockerfile): build from source with ref v2026.6.9713-cu128
- [x] Update RPi Dockerfile (rpi.Dockerfile): pip install xllamacpp==2026.6.9713

## Verification
- Confirmed latest available version via `pip index versions xllamacpp`: **2026.6.9713** is the latest release
- Verified no remaining references to old version 2026.6.9538 exist in any Dockerfiles
- All 5 Dockerfiles modified with consistent version updates

## Notes / Blockers
- No blockers; this is a straightforward version bump
- Jetson builds from source using tag `v2026.6.9713-cu128`, which should correspond to the same release
- All other platforms use prebuilt wheels from PyPI or platform-specific index URLs