### PR TITLE
Fix Qwen TTS stream speed

### DIFF
--- a/ezlocalai/CTTS.py
+++ b/ezlocalai/CTTS.py
@@ -29,8 +29,6 @@ from ezlocalai.AudioCache import AudioCache
 QWEN_TTS_MODEL = "Qwen/Qwen3-TTS-12Hz-0.6B-Base"
 MAX_CHUNK_CHARS = 350
 STREAM_CHUNK_TARGET_CHARS = 160
-STREAM_MIN_NEW_TOKENS = 48
-STREAM_TOKEN_PADDING = 24
 SAFE_FILE_STEM_RE = re.compile(r"[^a-zA-Z0-9_-]")
 
 LANGUAGE_ALIASES = {
@@ -575,21 +573,6 @@ class CTTS:
             kwargs["max_new_tokens"] = max_tokens
         return kwargs
 
-    def _stream_generation_kwargs(self, text: str) -> dict:
-        kwargs = dict(self.generation_kwargs)
-        configured = kwargs.get("max_new_tokens")
-        if not isinstance(configured, int) or configured <= 0:
-            configured = _env_int("QWEN_TTS_MAX_NEW_TOKENS", 320)
-
-        compact_len = len(re.sub(r"\s+", "", text))
-        punctuation_count = len(re.findall(r"[.!?。！？,;:，；：]", text))
-        estimated_tokens = int(compact_len * 1.1) + (punctuation_count * 6)
-        estimated_tokens += STREAM_TOKEN_PADDING
-        kwargs["max_new_tokens"] = max(
-            STREAM_MIN_NEW_TOKENS, min(configured, estimated_tokens)
-        )
-        return kwargs
-
     def _release_generation_memory(self):
         gc.collect()
         if (
@@ -931,7 +914,6 @@ class CTTS:
                     qwen_language,
                     ref_text,
                     x_vector_only,
-                    self._stream_generation_kwargs(chunk),
                 )
                 self.sample_rate = int(sample_rate)
                 pcm_data = self._array_to_pcm16_bytes(wav)

--- a/test_ctts_chunking.py
+++ b/test_ctts_chunking.py
@@ -1,0 +1,66 @@
+import pathlib
+import sys
+import types
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+qwen_tts_stub = types.ModuleType("qwen_tts")
+qwen_tts_stub.Qwen3TTSModel = object
+sys.modules.setdefault("qwen_tts", qwen_tts_stub)
+
+from ezlocalai.CTTS import clean_text_for_tts, split_text_into_stream_chunks
+
+
+class CTTSChunkingTests(unittest.TestCase):
+    def test_stream_chunks_preserve_multilingual_sentences(self):
+        text = clean_text_for_tts(
+            "Hello. Привет, как дела? Повтори слово спасибо. Now say it slowly."
+        )
+
+        chunks = split_text_into_stream_chunks(text, target_chars=40)
+
+        self.assertEqual(
+            chunks,
+            [
+                "Hello.",
+                "Привет, как дела?",
+                "Повтори слово спасибо.",
+                "Now say it slowly.",
+            ],
+        )
+        self.assertEqual(" ".join(chunks), text)
+
+    def test_stream_chunks_do_not_truncate_long_text(self):
+        text = clean_text_for_tts(
+            " ".join(
+                [
+                    "Это",
+                    "длинный",
+                    "пример",
+                    "русского",
+                    "текста",
+                    "который",
+                    "должен",
+                    "разбиваться",
+                    "на",
+                    "несколько",
+                    "частей",
+                    "без",
+                    "потери",
+                    "слов.",
+                ]
+            )
+        )
+
+        chunks = split_text_into_stream_chunks(text, target_chars=25)
+
+        self.assertGreater(len(chunks), 1)
+        self.assertEqual(" ".join(chunks), text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- remove the per-stream dynamic max_new_tokens limiter that made Qwen TTS output sound sped up/truncated
- keep sentence-first stream chunking without dropping long multilingual text
- add regression tests for Russian/English chunk preservation and long-text non-truncation

## Tests
- python -m black ezlocalai/CTTS.py test_ctts_chunking.py
- python -m py_compile ezlocalai/CTTS.py test_ctts_chunking.py
- python -m unittest test_ctts_chunking.py
- git diff --check
- docker compose -f docker-compose-cuda.yml down && docker compose -f docker-compose-cuda.yml up -d --build
- ezlocalai health check reached healthy
- live local /v1/audio/speech/stream probe returned 200 with 24 kHz/16-bit/mono header and first normal-budget PCM frame at ~15.9s