### PR TITLE
Improve Qwen TTS streaming behavior

### DIFF
--- a/Router.py
+++ b/Router.py
@@ -46,7 +46,7 @@ from Tunnel import is_tunnel_url
 
 ALL_CAPABILITIES = {"text", "vision", "tts", "stt", "image", "video", "embedding"}
 MODEL_STRICT_CAPABILITIES = {"text", "vision"}
-DEFAULT_DEDICATED_CAPABILITY_PREFERENCES = {"stt", "tts"}
+DEFAULT_DEDICATED_CAPABILITY_PREFERENCES = {"stt"}
 _RUNTIME_VERSION_CACHE: Optional[str] = None
 
 

--- a/ezlocalai/CTTS.py
+++ b/ezlocalai/CTTS.py
@@ -205,14 +205,42 @@ def split_text_into_chunks(text: str, max_chars: int = MAX_CHUNK_CHARS) -> list[
 def split_text_into_stream_chunks(
     text: str, target_chars: int = STREAM_CHUNK_TARGET_CHARS
 ) -> list[str]:
-    """Split streaming text by sentence without dropping any input text."""
+    """Split streaming text into natural speech units without dropping text."""
     target_chars = max(1, target_chars)
+    sentence_pair_size = 2
     chunks = []
+    current_chunk = ""
+    current_sentences = 0
+
+    def flush_current():
+        nonlocal current_chunk, current_sentences
+        if current_chunk:
+            chunks.append(current_chunk.strip())
+        current_chunk = ""
+        current_sentences = 0
+
     for sentence in re.split(r"(?<=[.!?。！？])\s+", text):
         sentence = sentence.strip()
         if not sentence:
             continue
-        chunks.extend(split_text_into_chunks(sentence, target_chars))
+
+        if len(sentence) > target_chars:
+            flush_current()
+            chunks.extend(split_text_into_chunks(sentence, target_chars))
+            continue
+
+        would_exceed = (
+            current_chunk and len(current_chunk) + len(sentence) + 1 > target_chars
+        )
+        if current_sentences >= sentence_pair_size or would_exceed:
+            flush_current()
+
+        current_chunk = (current_chunk + " " + sentence).strip()
+        current_sentences += 1
+        if current_sentences >= sentence_pair_size:
+            flush_current()
+
+    flush_current()
     return chunks or ([text] if text else [])
 
 

--- a/router_app.py
+++ b/router_app.py
@@ -2638,6 +2638,8 @@ async def _proxy_via_tunnel(
     timeout: Optional[float],
     capability: Optional[str] = None,
     model: Optional[str] = None,
+    stream_media_type: Optional[str] = None,
+    stream_headers: Optional[Dict[str, str]] = None,
 ):
     """Route a request to a tunneled worker through its open WebSocket."""
     hub = get_tunnel_hub()
@@ -2719,7 +2721,11 @@ async def _proxy_via_tunnel(
                 worker.worker_id, -1, capability=capability, model=model
             )
 
-    return StreamingResponse(gen(), media_type=media_type or "text/event-stream")
+    return StreamingResponse(
+        gen(),
+        media_type=stream_media_type or media_type or "text/event-stream",
+        headers=stream_headers,
+    )
 
 
 async def _proxy_json(
@@ -2731,6 +2737,8 @@ async def _proxy_json(
     timeout: Optional[float] = None,
     capability: Optional[str] = None,
     model: Optional[str] = None,
+    stream_media_type: Optional[str] = None,
+    stream_headers: Optional[Dict[str, str]] = None,
 ):
     """Forward a JSON POST to a worker. Returns either a dict or a StreamingResponse."""
     headers = {"Content-Type": "application/json", **_worker_headers(worker)}
@@ -2745,6 +2753,8 @@ async def _proxy_json(
             timeout=timeout,
             capability=capability,
             model=model,
+            stream_media_type=stream_media_type,
+            stream_headers=stream_headers,
         )
     url = f"{worker.url}{path}"
     timeout_seconds = timeout or float(getenv("REQUEST_TIMEOUT", "300"))
@@ -2829,7 +2839,11 @@ async def _proxy_json(
                 worker.worker_id, -1, capability=capability, model=model
             )
 
-    return StreamingResponse(gen(), media_type="text/event-stream")
+    return StreamingResponse(
+        gen(),
+        media_type=stream_media_type or "text/event-stream",
+        headers=stream_headers,
+    )
 
 
 def _stream_max_attempts(capability: str) -> int:
@@ -3635,7 +3649,18 @@ async def audio_speech(
 async def audio_speech_stream(payload: Dict[str, Any], _: str = Depends(verify_client)):
     worker = await _pick("tts", payload.get("model"))
     resp = await _proxy_json(
-        worker, "/v1/audio/speech/stream", payload, stream=True, capability="tts"
+        worker,
+        "/v1/audio/speech/stream",
+        payload,
+        stream=True,
+        capability="tts",
+        stream_media_type="application/octet-stream",
+        stream_headers={
+            "X-Audio-Format": "pcm",
+            "X-Sample-Rate": "24000",
+            "X-Bits-Per-Sample": "16",
+            "X-Channels": "1",
+        },
     )
     await _usage.record_cap(worker.label, "tts")
     return resp

--- a/test_ctts_chunking.py
+++ b/test_ctts_chunking.py
@@ -21,15 +21,30 @@ class CTTSChunkingTests(unittest.TestCase):
             "Hello. Привет, как дела? Повтори слово спасибо. Now say it slowly."
         )
 
-        chunks = split_text_into_stream_chunks(text, target_chars=40)
+        chunks = split_text_into_stream_chunks(text, target_chars=50)
 
         self.assertEqual(
             chunks,
             [
-                "Hello.",
-                "Привет, как дела?",
-                "Повтори слово спасибо.",
-                "Now say it slowly.",
+                "Hello. Привет, как дела?",
+                "Повтори слово спасибо. Now say it slowly.",
+            ],
+        )
+        self.assertEqual(" ".join(chunks), text)
+
+    def test_stream_chunks_pair_short_sentences_for_natural_playback(self):
+        text = clean_text_for_tts(
+            "Hello. This is the second sentence. "
+            "Here is Russian: Привет, как дела? Now this is the final sentence."
+        )
+
+        chunks = split_text_into_stream_chunks(text, target_chars=160)
+
+        self.assertEqual(
+            chunks,
+            [
+                "Hello. This is the second sentence.",
+                "Here is Russian: Привет, как дела? Now this is the final sentence.",
             ],
         )
         self.assertEqual(" ".join(chunks), text)

--- a/test_router_selection.py
+++ b/test_router_selection.py
@@ -341,7 +341,7 @@ class RouterSelectionTests(unittest.TestCase):
         self.assertIsNotNone(worker)
         self.assertEqual(worker.label, "TTS Worker")
 
-    def test_tts_prefers_dedicated_voice_worker_over_high_tier_text_worker(self):
+    def test_tts_prefers_high_tier_worker_over_dedicated_voice_worker_by_default(self):
         registry = WorkerRegistry(ttl_seconds=60)
         registry.register(
             self._capability_worker(
@@ -354,6 +354,24 @@ class RouterSelectionTests(unittest.TestCase):
         router = Router(registry)
 
         worker = router.select_worker("tts", "tts-1", allow_cross_model=False)
+
+        self.assertIsNotNone(worker)
+        self.assertEqual(worker.worker_id, "mixed-5090")
+
+    def test_tts_dedicated_voice_preference_can_be_enabled(self):
+        registry = WorkerRegistry(ttl_seconds=60)
+        registry.register(
+            self._capability_worker(
+                "mixed-5090", ["text", "vision", "tts"], best_tier=90
+            )
+        )
+        registry.register(
+            self._capability_worker("voice-3090", ["tts", "stt"], best_tier=55)
+        )
+        router = Router(registry)
+
+        with patch.dict(os.environ, {"ROUTER_PREFER_DEDICATED_CAPABILITIES": "tts"}):
+            worker = router.select_worker("tts", "tts-1", allow_cross_model=False)
 
         self.assertIsNotNone(worker)
         self.assertEqual(worker.worker_id, "voice-3090")
@@ -407,9 +425,7 @@ class RouterSelectionTests(unittest.TestCase):
         router = Router(WorkerRegistry(ttl_seconds=60))
 
         worker = asyncio.run(
-            router.wait_for_worker(
-                "text", "model-a", timeout=0.01, poll_interval=0.001
-            )
+            router.wait_for_worker("text", "model-a", timeout=0.01, poll_interval=0.001)
         )
 
         self.assertIsNone(worker)

--- a/test_router_streaming.py
+++ b/test_router_streaming.py
@@ -87,6 +87,56 @@ class RouterStreamingTests(unittest.IsolatedAsyncioTestCase):
         self.assertIn('"content":"ok"', body)
         self.assertNotIn("request exceeds context", body)
 
+    async def test_audio_speech_stream_uses_binary_pcm_response_metadata(self):
+        worker = WorkerInfo(
+            worker_id="tts-worker",
+            label="tts-worker",
+            url="http://tts-worker",
+            capabilities=["tts"],
+            models=[],
+        )
+        captured = {}
+        original_pick = router_app._pick
+        original_proxy = router_app._proxy_json
+        original_record_cap = router_app._usage.record_cap
+
+        async def fake_pick(capability, model, exclude=None):
+            self.assertEqual(capability, "tts")
+            return worker
+
+        async def fake_proxy(worker_arg, path, payload, **kwargs):
+            captured.update(kwargs)
+            captured["path"] = path
+            captured["payload"] = payload
+            return router_app.Response(
+                content=b"", media_type=kwargs["stream_media_type"]
+            )
+
+        async def fake_record_cap(label, capability):
+            captured["usage"] = (label, capability)
+
+        try:
+            router_app._pick = fake_pick
+            router_app._proxy_json = fake_proxy
+            router_app._usage.record_cap = fake_record_cap
+
+            response = await router_app.audio_speech_stream(
+                {"model": "tts-1", "input": "Hello."}, _="test-client"
+            )
+        finally:
+            router_app._pick = original_pick
+            router_app._proxy_json = original_proxy
+            router_app._usage.record_cap = original_record_cap
+
+        self.assertEqual(captured["path"], "/v1/audio/speech/stream")
+        self.assertTrue(captured["stream"])
+        self.assertEqual(captured["capability"], "tts")
+        self.assertEqual(captured["stream_media_type"], "application/octet-stream")
+        self.assertEqual(captured["stream_headers"]["X-Audio-Format"], "pcm")
+        self.assertEqual(captured["stream_headers"]["X-Sample-Rate"], "24000")
+        self.assertEqual(response.media_type, "application/octet-stream")
+        self.assertEqual(captured["usage"], ("tts-worker", "tts"))
+
 
 class RouterTimeoutTests(unittest.TestCase):
     def test_stt_timeout_defaults_to_large_transcription_window(self):


### PR DESCRIPTION
## Summary
- group short streaming TTS sentences into more natural Qwen generation chunks instead of one generation per sentence
- stop preferring dedicated media workers for TTS by default so TTS routes to faster high-tier workers unless explicitly configured otherwise
- return binary PCM metadata for the router TTS stream endpoint instead of SSE metadata

## Verification
- python -m black Router.py router_app.py ezlocalai/CTTS.py test_ctts_chunking.py test_router_selection.py test_router_streaming.py
- python -m py_compile Router.py router_app.py ezlocalai/CTTS.py test_ctts_chunking.py test_router_selection.py test_router_streaming.py
- python -m unittest test_ctts_chunking.py test_router_selection.py test_router_streaming.py
- git diff --check
- docker compose -f docker-compose-cuda.yml down && docker compose -f docker-compose-cuda.yml up -d --build
- local worker /v1/audio/speech/stream probe: 200 application/octet-stream, stream header in 0.026s, first audio payload in 1.822s, language=Auto, 3 grouped payloads for a 131-char mixed English/Russian sample
- simulated patched router selection against live worker pool: default TTS selects DevXT5090; explicit ROUTER_PREFER_DEDICATED_CAPABILITIES=tts selects DevXT3090A
