### PR TITLE
Show music models on router dashboard

### DIFF
--- a/Router.py
+++ b/Router.py
@@ -39,6 +39,7 @@ import aiohttp
 
 from Globals import getenv
 from Tunnel import is_tunnel_url
+from ezlocalai.MUSIC import ACE_STEP_DEFAULT_MODEL as ACE_STEP_DEFAULT_MUSIC_MODEL
 
 # ---------------------------------------------------------------------------
 # Capability detection
@@ -363,7 +364,10 @@ def detect_local_capabilities() -> List[str]:
     embedding_server = (getenv("EMBEDDING_SERVER") or "").strip().lower()
     img_model = (getenv("IMG_MODEL") or "").strip().lower()
     video_model = (getenv("VIDEO_MODEL") or "").strip().lower()
-    music_model = (getenv("MUSIC_MODEL") or "").strip().lower()
+    music_model = (
+        getenv("MUSIC_MODEL", ACE_STEP_DEFAULT_MUSIC_MODEL)
+        or ACE_STEP_DEFAULT_MUSIC_MODEL
+    ).strip().lower()
     tts_enabled = (getenv("TTS_ENABLED") or "true").strip().lower() == "true"
     stt_enabled = (getenv("STT_ENABLED") or "true").strip().lower() == "true"
     image_enabled = (getenv("IMAGE_ENABLED") or "false").strip().lower() == "true"
@@ -1937,8 +1941,11 @@ class WorkerHeartbeatClient:
                 if _vm:
                     cap_models["video"] = _vm
             elif _cap == "music":
-                _mm = (getenv("MUSIC_MODEL") or "").strip()
-                if _mm:
+                _mm = (
+                    getenv("MUSIC_MODEL", ACE_STEP_DEFAULT_MUSIC_MODEL)
+                    or ACE_STEP_DEFAULT_MUSIC_MODEL
+                ).strip()
+                if _mm and _mm.lower() != "none":
                     cap_models["music"] = _mm
             elif _cap == "embedding":
                 _em = (getenv("EMBEDDING_MODEL_ALIAS") or "").strip() or (

--- a/router_app.py
+++ b/router_app.py
@@ -1743,7 +1743,7 @@ def _render_dashboard_html(data: Dict[str, Any]) -> str:
                 f"{html.escape(_pretty_model_name(emb_name))}"
                 f"{emb_quant_part}{emb_ctx_part}</span>"
             )
-        for cap in ("image", "tts", "stt", "video"):
+        for cap in ("image", "tts", "stt", "video", "music"):
             if cap in raw_caps_for_models:
                 cap_name = cap_models_map.get(cap) or _cap_label(cap)
                 if cap == "stt":
@@ -1846,6 +1846,7 @@ def _render_dashboard_html(data: Dict[str, Any]) -> str:
         stt_reqs = (wdata.get("stt") or {}).get("requests", 0)
         img_reqs = (wdata.get("image") or {}).get("requests", 0)
         vid_reqs = (wdata.get("video") or {}).get("requests", 0)
+        music_reqs = (wdata.get("music") or {}).get("requests", 0)
         emb_reqs = (wdata.get("embedding") or {}).get("requests", 0)
         return f"""
         <tr>
@@ -1856,6 +1857,7 @@ def _render_dashboard_html(data: Dict[str, Any]) -> str:
           <td class="num">{stt_reqs:,}</td>
           <td class="num">{img_reqs:,}</td>
           <td class="num">{vid_reqs:,}</td>
+          <td class="num">{music_reqs:,}</td>
         </tr>"""
 
     # ---- Recent request history -------------------------------------------
@@ -1926,14 +1928,14 @@ def _render_dashboard_html(data: Dict[str, Any]) -> str:
             )
             cap_reqs = sum(
                 int((wd.get(cap) or {}).get("requests", 0) or 0)
-                for cap in ("embedding", "tts", "stt", "image", "video")
+                for cap in ("embedding", "tts", "stt", "image", "video", "music")
             )
             return llm_reqs + cap_reqs
 
         ordered = sorted(usage_src.items(), key=lambda kv: (-_total_reqs(kv[1]), kv[0]))
         return (
             "".join(_usage_summary_row(lbl, wd) for lbl, wd in ordered)
-            or '<tr><td colspan="7" class="muted">No usage recorded in this window.</td></tr>'
+            or '<tr><td colspan="8" class="muted">No usage recorded in this window.</td></tr>'
         )
 
     def _build_breakdown_rows(usage_src: Dict[str, Any]) -> str:
@@ -2301,6 +2303,7 @@ def _render_dashboard_html(data: Dict[str, Any]) -> str:
       <th class="num">Embedding reqs</th>
       <th class="num">TTS reqs</th><th class="num">STT reqs</th>
       <th class="num">Image reqs</th><th class="num">Video reqs</th>
+      <th class="num">Music reqs</th>
     </tr></thead>
     <tbody class="usage-tbody" data-window="all">{usage_summary_rows_all}</tbody>
     <tbody class="usage-tbody" data-window="24h" style="display:none">{usage_summary_rows_24h}</tbody>

--- a/test_music_generation.py
+++ b/test_music_generation.py
@@ -292,6 +292,30 @@ class MusicRouterTests(unittest.TestCase):
 
         self.assertIn("music", caps)
 
+    def test_enabled_music_advertises_default_when_model_env_is_blank(self):
+        with patch.dict(
+            os.environ,
+            {
+                "DEFAULT_MODEL": "none",
+                "VOICE_SERVER": "",
+                "IMAGE_SERVER": "",
+                "TEXT_SERVER": "",
+                "EMBEDDING_SERVER": "",
+                "TTS_ENABLED": "false",
+                "STT_ENABLED": "false",
+                "EMBEDDING_ENABLED": "false",
+                "IMAGE_ENABLED": "false",
+                "VIDEO_ENABLED": "false",
+                "MUSIC_ENABLED": "true",
+                "MUSIC_MODEL": "",
+                "ACE_STEP_SERVER_URL": "",
+            },
+            clear=True,
+        ):
+            caps = detect_local_capabilities()
+
+        self.assertIn("music", caps)
+
     def test_music_generation_slot_state_makes_text_unavailable(self):
         registry = WorkerRegistry(ttl_seconds=60)
         registry.register(

--- a/test_router_dashboard.py
+++ b/test_router_dashboard.py
@@ -1,7 +1,38 @@
 import unittest
 
 from Router import WorkerInfo
-from router_app import _public_with_tunnel, _tier_badge, _worker_priority_tier
+from router_app import (
+    _public_with_tunnel,
+    _render_dashboard_html,
+    _tier_badge,
+    _worker_priority_tier,
+)
+
+
+def _dashboard_data(**overrides):
+    data = {
+        "pool_health": "healthy",
+        "router": {"ttl_seconds": 60, "wait_timeout": 30},
+        "totals": {
+            "alive_workers": 1,
+            "stale_workers": 0,
+            "total_parallel_capacity": 1,
+            "total_available_slots": 1,
+            "total_in_flight": 0,
+            "total_queue_depth": 0,
+            "total_free_vram_gb": 0,
+            "total_vram_gb": 0,
+            "unique_models": 0,
+        },
+        "models": [],
+        "workers": [],
+        "usage": {},
+        "usage_24h": {},
+        "history": [],
+        "errors": [],
+    }
+    data.update(overrides)
+    return data
 
 
 class RouterDashboardTierTests(unittest.TestCase):
@@ -33,6 +64,43 @@ class RouterDashboardTierTests(unittest.TestCase):
         self.assertIn("priority tier 50", badge)
         self.assertIn("hw 55", badge)
         self.assertIn("tunnel penalty -5", badge)
+
+    def test_worker_models_column_shows_music_model(self):
+        worker = WorkerInfo(
+            worker_id="music-1",
+            label="Studio",
+            url="http://studio.local",
+            capabilities=["music"],
+            cap_models={"music": "Serveurperso/ACE-Step-1.5-GGUF"},
+            cap_slots={
+                "music": {
+                    "capacity": 1,
+                    "in_flight": 0,
+                    "queued": 0,
+                    "available": 1,
+                }
+            },
+        )
+        html = _render_dashboard_html(
+            _dashboard_data(workers=[_public_with_tunnel(worker)])
+        )
+
+        self.assertIn('title="Serveurperso/ACE-Step-1.5-GGUF"', html)
+        self.assertIn(">ACE-Step-1.5</span>", html)
+
+    def test_usage_summary_shows_music_requests(self):
+        html = _render_dashboard_html(
+            _dashboard_data(
+                usage={
+                    "Studio": {
+                        "music": {"requests": 3},
+                    }
+                }
+            )
+        )
+
+        self.assertIn("Music reqs", html)
+        self.assertIn('<td class="num">3</td>', html)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- show music capability models in the worker table's Models column
- keep MUSIC_ENABLED=true advertising the default ACE-Step model even if MUSIC_MODEL is blank
- add Music request counts to the dashboard usage summary

## Tests
- python -m py_compile Router.py router_app.py test_router_dashboard.py test_music_generation.py
- python -m unittest test_router_dashboard.py test_music_generation.py
- python -m unittest test_router_dashboard.py test_router_selection.py test_music_generation.py test_router_streaming.py
- git diff --check