### PR TITLE
Avoid music package import in router core

### DIFF
--- a/Router.py
+++ b/Router.py
@@ -39,7 +39,6 @@ import aiohttp
 
 from Globals import getenv
 from Tunnel import is_tunnel_url
-from ezlocalai.MUSIC import ACE_STEP_DEFAULT_MODEL as ACE_STEP_DEFAULT_MUSIC_MODEL
 
 # ---------------------------------------------------------------------------
 # Capability detection
@@ -57,6 +56,7 @@ ALL_CAPABILITIES = {
 }
 MODEL_STRICT_CAPABILITIES = {"text", "vision"}
 DEFAULT_DEDICATED_CAPABILITY_PREFERENCES = {"stt"}
+ACE_STEP_DEFAULT_MUSIC_MODEL = "Serveurperso/ACE-Step-1.5-GGUF"
 _RUNTIME_VERSION_CACHE: Optional[str] = None
 
 


### PR DESCRIPTION
## Summary
- keep Router.py self-contained by defining the ACE-Step music display default locally
- preserves the MUSIC_ENABLED=true default advertisement from PR #92 without requiring ezlocalai.MUSIC to exist in router-only deployments

## Why
Some router deployments update or mount only Router.py/router_app.py into an existing router image. Importing ezlocalai.MUSIC from Router.py can crash those deployments even though the dashboard code itself does not need the music runtime package.

## Tests
- python -m py_compile Router.py router_app.py test_router_dashboard.py test_music_generation.py
- python -m unittest test_router_dashboard.py test_music_generation.py
- python -m unittest test_router_dashboard.py test_router_selection.py test_music_generation.py test_router_streaming.py
- git diff --check
- docker restart ezlocalai-router && curl -sf http://localhost:8092/health
- disposable music worker registration showed ACE-Step-1.5 in /dashboard worker Models column