### PR TITLE
chore: update xllamacpp to 2026.8.10566

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN python3 -m pip install "gTTS>=2.4.0" --no-deps --no-cache-dir
 RUN pip install esp-ppq --no-deps --no-cache-dir
 
 # Install xllamacpp CPU version
-RUN pip install xllamacpp==2026.8.10229 --force-reinstall --no-cache-dir
+RUN pip install xllamacpp==2026.8.10566 --force-reinstall --no-cache-dir
 
 COPY . .
 ENV HOST=0.0.0.0 \

--- a/cuda.Dockerfile
+++ b/cuda.Dockerfile
@@ -60,7 +60,7 @@ ENV HOST=0.0.0.0 \
     HF_HUB_CACHE=/app/models \
     ACE_STEP_BIN=/opt/acestep.cpp/build/ace-server
 # Install xllamacpp with CUDA 12.8 support (compatible with CUDA 12.9)
-RUN uv pip install xllamacpp==2026.8.10229 --reinstall --index-url https://xorbitsai.github.io/xllamacpp/whl/cu128
+RUN uv pip install xllamacpp==2026.8.10566 --reinstall --index-url https://xorbitsai.github.io/xllamacpp/whl/cu128
 COPY . .
 EXPOSE 8091
 # Use start.py which runs precache once, then starts uvicorn workers

--- a/ezlocalai-colab.ipynb
+++ b/ezlocalai-colab.ipynb
@@ -91,7 +91,7 @@
     "!{UV_PIP} qwen-tts==0.1.1 --no-deps\n",
     "!{UV_PIP} 'gTTS>=2.4.0' --no-deps\n",
     "!{UV_PIP} esp-ppq --no-deps\n",
-    "!{UV_PIP} xllamacpp==2026.8.10229 --reinstall \\\n",
+    "!{UV_PIP} xllamacpp==2026.8.10566 --reinstall \\\n",
     "    --index-url https://xorbitsai.github.io/xllamacpp/whl/cu128"
    ]
   },

--- a/rocm.Dockerfile
+++ b/rocm.Dockerfile
@@ -34,7 +34,7 @@ ENV HOST=0.0.0.0 \
     HF_HOME=/app/models \
     HF_HUB_CACHE=/app/models
 # Install xllamacpp with ROCm 6.4.1 support
-RUN uv pip install xllamacpp==2026.8.10229 --reinstall --index-url https://xorbitsai.github.io/xllamacpp/whl/rocm-6.4.1
+RUN uv pip install xllamacpp==2026.8.10566 --reinstall --index-url https://xorbitsai.github.io/xllamacpp/whl/rocm-6.4.1
 COPY . .
 EXPOSE 8091
 # Use start.py which runs precache once, then starts uvicorn workers

--- a/rpi.Dockerfile
+++ b/rpi.Dockerfile
@@ -24,7 +24,7 @@ RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
     python3 -m pip install --no-cache-dir -r rpi-requirements.txt
 
 # Install xllamacpp - prebuilt aarch64 wheels available on PyPI
-RUN pip install xllamacpp==2026.8.10229 --force-reinstall --no-cache-dir
+RUN pip install xllamacpp==2026.8.10566 --force-reinstall --no-cache-dir
 
 COPY . .
 


### PR DESCRIPTION
## Summary
Bump pinned xllamacpp version from 2026.8.10229 to 2026.8.10566 in all Dockerfiles and the Colab notebook to match the latest release (v2026.8.10566-vulkan-windows-2022, published 2026-08-22).

## Plan executed
- [x] Check latest xllamacpp release version from GitHub
- [x] Clone ezlocalai repo and find all xllamacpp references
- [x] Update all xllamacpp version references to latest
- [x] Commit, push branch, and open PR

## Verification
- grep -rn confirmed 5 files with version pins: Dockerfile, cuda.Dockerfile, rocm.Dockerfile, rpi.Dockerfile, ezlocalai-colab.ipynb
- git diff --stat shows exactly 5 one-line changes (insertions/deletions) matching the expected version bump
- jetson.Dockerfile builds from source and does not have a version pin

## Notes / blockers
None