### PR TITLE
Preserve prompt cache affinity during worker contention

### DIFF
--- a/README.md
+++ b/README.md
@@ -628,10 +628,11 @@ By default, text/vision routing requires an idle worker, so one long-running req
 
 Requests that include the same `prompt_cache_key` keep affinity with the worker
 that owns their reusable prompt prefix. If that worker is briefly busy, the
-router waits up to `ROUTER_PROMPT_AFFINITY_WAIT` seconds (default `30`) before
+router waits up to `ROUTER_PROMPT_AFFINITY_WAIT` seconds (default `2`) before
 using another worker. Temporary spillover does not replace the cache-owning
-worker, so later turns return to the warm prefix. Set the value to `0` to use
-immediate spillover.
+worker, so later turns return to the warm prefix. The short default covers
+stream-release and heartbeat lag without queueing behind a long generation.
+Set the value to `0` to use immediate spillover.
 
 For capability-only voice routing, the router defaults `ROUTER_PREFER_DEDICATED_CAPABILITIES=stt`, so large STT transcription jobs prefer workers that are not also serving `text` or `vision`. TTS routes by the normal score/tier calculation by default so low-latency playback can use faster mixed-capability workers. Stale `ROUTER_PREFER_DEDICATED_CAPABILITIES=stt,tts` values are treated as STT-only for TTS unless `ROUTER_ALLOW_DEDICATED_TTS_PREFERENCE=true` is also set. Large transcription jobs also use `ROUTER_STT_TIMEOUT` (default `7200` seconds) instead of the generic `REQUEST_TIMEOUT`.
 

--- a/README.md
+++ b/README.md
@@ -626,6 +626,13 @@ score = priority_tier * 10  +  slots_left * 5  +  free_vram_gb  -  in_flight * 4
 
 By default, text/vision routing requires an idle worker, so one long-running request on the 5090 sends the next compatible request to an idle 4090/3090 instead of stacking it onto the 5090. `ROUTER_CROSS_MODEL_GRACE=0` means the router does not wait for a busy same-model worker before using the best available compatible fallback. `ROUTER_IDLE_TIER_WINDOW=0` means the router does not hold back lower-tier idle workers while a higher-tier worker is busy; set a positive value to restrict idle spillover to workers within that many tier points of the fastest compatible tier. Set `ROUTER_BUSY_SLOT_FALLBACK=true` to restore slot-based routing when every compatible text/vision worker is already busy.
 
+Requests that include the same `prompt_cache_key` keep affinity with the worker
+that owns their reusable prompt prefix. If that worker is briefly busy, the
+router waits up to `ROUTER_PROMPT_AFFINITY_WAIT` seconds (default `30`) before
+using another worker. Temporary spillover does not replace the cache-owning
+worker, so later turns return to the warm prefix. Set the value to `0` to use
+immediate spillover.
+
 For capability-only voice routing, the router defaults `ROUTER_PREFER_DEDICATED_CAPABILITIES=stt`, so large STT transcription jobs prefer workers that are not also serving `text` or `vision`. TTS routes by the normal score/tier calculation by default so low-latency playback can use faster mixed-capability workers. Stale `ROUTER_PREFER_DEDICATED_CAPABILITIES=stt,tts` values are treated as STT-only for TTS unless `ROUTER_ALLOW_DEDICATED_TTS_PREFERENCE=true` is also set. Large transcription jobs also use `ROUTER_STT_TIMEOUT` (default `7200` seconds) instead of the generic `REQUEST_TIMEOUT`.
 
 Workers missing the required capability (`text` / `vision` / `tts` / `stt` / `embedding` / `image` / `video` / `music`) or the requested model are filtered out before scoring. Stale workers (no heartbeat for `ROUTER_WORKER_TTL` seconds) are also excluded.

--- a/docker-compose-router.yml
+++ b/docker-compose-router.yml
@@ -29,6 +29,7 @@ services:
       # false = text/vision requests wait once every compatible node is busy.
       # true = after idle spillover, fill remaining parallel slots on busy nodes.
       - ROUTER_BUSY_SLOT_FALLBACK=${ROUTER_BUSY_SLOT_FALLBACK-false}
+      - ROUTER_PROMPT_AFFINITY_WAIT=${ROUTER_PROMPT_AFFINITY_WAIT:-30}
       # Optional managed text/vision overflow. When the key is set, Chutes is
       # advertised on the dashboard at t45 and used only after comparable or
       # faster internal workers are occupied.

--- a/docker-compose-router.yml
+++ b/docker-compose-router.yml
@@ -29,7 +29,7 @@ services:
       # false = text/vision requests wait once every compatible node is busy.
       # true = after idle spillover, fill remaining parallel slots on busy nodes.
       - ROUTER_BUSY_SLOT_FALLBACK=${ROUTER_BUSY_SLOT_FALLBACK-false}
-      - ROUTER_PROMPT_AFFINITY_WAIT=${ROUTER_PROMPT_AFFINITY_WAIT:-30}
+      - ROUTER_PROMPT_AFFINITY_WAIT=${ROUTER_PROMPT_AFFINITY_WAIT:-2}
       # Optional managed text/vision overflow. When the key is set, Chutes is
       # advertised on the dashboard at t45 and used only after comparable or
       # faster internal workers are occupied.

--- a/router_app.py
+++ b/router_app.py
@@ -3113,7 +3113,7 @@ def _prompt_affinity_wait_timeout() -> float:
     than waiting briefly for the worker that already owns its KV prefix. Keep
     the wait bounded so affinity never defeats worker failover.
     """
-    return max(0.0, _float_env("ROUTER_PROMPT_AFFINITY_WAIT", 30.0))
+    return max(0.0, _float_env("ROUTER_PROMPT_AFFINITY_WAIT", 2.0))
 
 
 def _eligible_affinity_worker(

--- a/router_app.py
+++ b/router_app.py
@@ -3106,6 +3106,37 @@ def _prune_prompt_affinity(now: float) -> None:
             _prompt_affinity.pop(key, None)
 
 
+def _prompt_affinity_wait_timeout() -> float:
+    """How long to wait for a conversation's cache-owning worker.
+
+    Re-evaluating a long prompt on another worker routinely costs much more
+    than waiting briefly for the worker that already owns its KV prefix. Keep
+    the wait bounded so affinity never defeats worker failover.
+    """
+    return max(0.0, _float_env("ROUTER_PROMPT_AFFINITY_WAIT", 30.0))
+
+
+def _eligible_affinity_worker(
+    worker: Optional[WorkerInfo],
+    capability: str,
+    model: Optional[str],
+    excluded: set,
+) -> bool:
+    if (
+        worker is None
+        or worker.worker_id in excluded
+        or worker.external_fallback
+        or capability not in worker.capabilities
+        or worker.is_circuit_open()
+    ):
+        return False
+    return bool(
+        not model
+        or not worker.models
+        or any(model_name_matches(model, served) for served in worker.models)
+    )
+
+
 async def _pick(
     capability: str,
     model: Optional[str] = None,
@@ -3140,37 +3171,41 @@ async def _pick(
     preferred_id = (
         _prompt_affinity.get(affinity_key, (None, 0.0))[0] if affinity_key else None
     )
-    if preferred_id and preferred_id not in pre_exclude:
-        preferred = next(
-            (
-                worker
-                for worker in registry.list_workers(alive_only=True)
-                if worker.worker_id == preferred_id
-            ),
-            None,
-        )
-        model_matches = bool(
-            preferred
-            and (
-                not model
-                or not preferred.models
-                or any(model_name_matches(model, served) for served in preferred.models)
+    preferred: Optional[WorkerInfo] = None
+    preferred_is_eligible = False
+    if preferred_id:
+        affinity_wait = _prompt_affinity_wait_timeout()
+        affinity_deadline = time.monotonic() + affinity_wait
+        while True:
+            preferred = next(
+                (
+                    worker
+                    for worker in registry.list_workers(alive_only=True)
+                    if worker.worker_id == preferred_id
+                ),
+                None,
             )
-        )
-        if (
-            preferred
-            and not preferred.external_fallback
-            and capability in preferred.capabilities
-            and not preferred.is_circuit_open()
-            and model_matches
-            and preferred.has_capacity(capability, model)
-        ):
-            _prompt_affinity[affinity_key] = (preferred.worker_id, now)
-            logging.info(
-                f"[Router] prompt-cache affinity -> {preferred.label} "
-                f"(model={model!r}, cap={capability})"
+            preferred_is_eligible = _eligible_affinity_worker(
+                preferred, capability, model, pre_exclude
             )
-            return preferred
+            if not preferred_is_eligible:
+                break
+            if preferred.has_capacity(capability, model):
+                _prompt_affinity[affinity_key] = (preferred.worker_id, time.time())
+                logging.info(
+                    f"[Router] prompt-cache affinity -> {preferred.label} "
+                    f"(model={model!r}, cap={capability})"
+                )
+                return preferred
+            remaining = affinity_deadline - time.monotonic()
+            if remaining <= 0:
+                logging.info(
+                    f"[Router] prompt-cache affinity worker {preferred.label} "
+                    f"remained busy for {affinity_wait:.1f}s; "
+                    "using temporary spillover without moving its cache home"
+                )
+                break
+            await asyncio.sleep(min(0.1, remaining))
     worker = await router.wait_for_worker(
         capability,
         model,
@@ -3185,8 +3220,12 @@ async def _pick(
                 + (f" model={model!r}" if model else "")
             ),
         )
-    if affinity_key and not worker.external_fallback:
-        _prompt_affinity[affinity_key] = (worker.worker_id, now)
+    if (
+        affinity_key
+        and not worker.external_fallback
+        and (not preferred_is_eligible or worker.worker_id == preferred_id)
+    ):
+        _prompt_affinity[affinity_key] = (worker.worker_id, time.time())
     return worker
 
 

--- a/test_router_streaming.py
+++ b/test_router_streaming.py
@@ -1,6 +1,7 @@
 import os
 import pathlib
 import sys
+import asyncio
 import unittest
 from unittest.mock import AsyncMock, patch
 
@@ -58,6 +59,92 @@ class RouterStreamingTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(selected_first.worker_id, "first")
         self.assertEqual(selected_second.worker_id, "first")
         router.wait_for_worker.assert_awaited_once()
+
+    async def test_prompt_affinity_waits_for_cached_worker_to_become_available(self):
+        registry = WorkerRegistry(ttl_seconds=60)
+        first = registry.register(
+            WorkerInfo(
+                worker_id="first",
+                label="first",
+                url="http://first",
+                capabilities=["text"],
+                models=["model"],
+            )
+        )
+        router = type(
+            "FakeRouter",
+            (),
+            {"wait_for_worker": AsyncMock(return_value=first)},
+        )()
+        router_app._prompt_affinity.clear()
+
+        with patch("router_app.get_registry", return_value=registry), patch(
+            "router_app.get_router", return_value=router
+        ), patch.dict(os.environ, {"ROUTER_PROMPT_AFFINITY_WAIT": "0.25"}):
+            selected_first = await router_app._pick(
+                "text", "model", affinity_key="text:model:conversation"
+            )
+            first.queue_depth = 1
+
+            async def release_cached_worker():
+                await asyncio.sleep(0.03)
+                first.queue_depth = 0
+
+            release = asyncio.create_task(release_cached_worker())
+            selected_second = await router_app._pick(
+                "text", "model", affinity_key="text:model:conversation"
+            )
+            await release
+
+        self.assertEqual(selected_first.worker_id, "first")
+        self.assertEqual(selected_second.worker_id, "first")
+        router.wait_for_worker.assert_awaited_once()
+
+    async def test_temporary_spillover_does_not_replace_cache_home(self):
+        registry = WorkerRegistry(ttl_seconds=60)
+        first = registry.register(
+            WorkerInfo(
+                worker_id="first",
+                label="first",
+                url="http://first",
+                capabilities=["text"],
+                models=["model"],
+            )
+        )
+        second = registry.register(
+            WorkerInfo(
+                worker_id="second",
+                label="second",
+                url="http://second",
+                capabilities=["text"],
+                models=["model"],
+            )
+        )
+        router = type(
+            "FakeRouter",
+            (),
+            {"wait_for_worker": AsyncMock(side_effect=[first, second])},
+        )()
+        affinity_key = "text:model:conversation"
+        router_app._prompt_affinity.clear()
+
+        with patch("router_app.get_registry", return_value=registry), patch(
+            "router_app.get_router", return_value=router
+        ), patch.dict(os.environ, {"ROUTER_PROMPT_AFFINITY_WAIT": "0.01"}):
+            await router_app._pick("text", "model", affinity_key=affinity_key)
+            first.queue_depth = 1
+            selected_spillover = await router_app._pick(
+                "text", "model", affinity_key=affinity_key
+            )
+            first.queue_depth = 0
+            selected_after_spillover = await router_app._pick(
+                "text", "model", affinity_key=affinity_key
+            )
+
+        self.assertEqual(selected_spillover.worker_id, "second")
+        self.assertEqual(selected_after_spillover.worker_id, "first")
+        self.assertEqual(router_app._prompt_affinity[affinity_key][0], "first")
+        self.assertEqual(router.wait_for_worker.await_count, 2)
 
     def test_llamacpp_timings_report_total_cached_and_evaluated_prompt_tokens(self):
         timings = {}


### PR DESCRIPTION
## Summary
- briefly wait for the worker that owns a request's `prompt_cache_key` prefix before spilling to another GPU
- preserve the original cache-home mapping during temporary spillover so later turns return to the warm worker
- expose `ROUTER_PROMPT_AFFINITY_WAIT` with a 2-second default and document how to disable the wait
- cover both affinity waiting and spillover recovery with router tests

## Why
Live testing reproduced a cache-breaking route sequence for one conversation: the first request ran on DevXT5090, an immediate repeat moved to DevXT4090 and missed its prompt cache, and the following request returned to DevXT5090 and reused about 22.5k cached tokens in under a second. The router previously abandoned affinity as soon as the preferred worker was briefly busy and replaced the affinity mapping with the spillover worker.

The two-second grace covers stream-release and heartbeat lag without queueing behind a genuinely long generation. Router dispatch reservations remain separate: they prevent concurrent requests from selecting the same apparently free slot before worker heartbeat state catches up.

This complements Josh-XT/WorkConductor#170, which prevents resumed continuation context from growing past the useful compaction threshold before the next inference.

## Verification
- `pytest -q` (193 passed, 1 skipped)
- `pytest -q test_router_*.py` (116 passed)
- `black --check router_app.py test_router_streaming.py`
- rebuilt `docker-compose-cuda.yml` and recreated `docker-compose-router.yml`
- worker and router health checks pass; post-rebuild logs contain no errors