### PR TITLE
Preserve prompt cache affinity across busy model workers

### DIFF
--- a/Pipes.py
+++ b/Pipes.py
@@ -9093,6 +9093,36 @@ class Pipes:
                 f"[Inference] Started - active count: {self._inference_count}"
             )
 
+    async def _acquire_inference_slot(self, model_name: Optional[str] = None):
+        """Register an inference, waiting before a swap across active models."""
+        waiting_for = None
+        while True:
+            with self._inference_count_lock:
+                conflicts = {
+                    name: count
+                    for name, count in self._model_inference_counts.items()
+                    if count > 0 and name != model_name
+                }
+                if self.llm_model_residency != "swap" or not conflicts:
+                    self._inference_count += 1
+                    if model_name:
+                        self._model_inference_counts[model_name] = (
+                            self._model_inference_counts.get(model_name, 0) + 1
+                        )
+                    logging.debug(
+                        "[Inference] Started - active count: %s",
+                        self._inference_count,
+                    )
+                    return
+            if conflicts != waiting_for:
+                logging.info(
+                    "[LLM Residency] Waiting to switch to %s while %s finishes",
+                    model_name,
+                    conflicts,
+                )
+                waiting_for = conflicts
+            await asyncio.sleep(0.05)
+
     def _decrement_inference_count(self, model_name: Optional[str] = None):
         """Thread-safe decrement of inference counter."""
         with self._inference_count_lock:
@@ -9193,7 +9223,7 @@ class Pipes:
         # Mark inference as in progress to prevent context reset during processing
         # and to expose per-model slot usage to the router heartbeat.
         slot_model = self._resolve_slot_model(data)
-        self._increment_inference_count(slot_model)
+        await self._acquire_inference_slot(slot_model)
 
         # Keep resource diagnostics accurate for the common resident-model
         # path. Swap-mode safety is governed by the inference counter above,

--- a/README.md
+++ b/README.md
@@ -628,7 +628,7 @@ By default, text/vision routing requires an idle worker, so one long-running req
 
 Requests that include the same `prompt_cache_key` keep affinity with the worker
 that owns their reusable prompt prefix. If that worker is briefly busy, the
-router waits up to `ROUTER_PROMPT_AFFINITY_WAIT` seconds (default `2`) before
+router waits up to `ROUTER_PROMPT_AFFINITY_WAIT` seconds (default `15`) before
 using another worker. Temporary spillover does not replace the cache-owning
 worker, so later turns return to the warm prefix. The short default covers
 stream-release and heartbeat lag without queueing behind a long generation.

--- a/Router.py
+++ b/Router.py
@@ -1451,6 +1451,32 @@ class WorkerRegistry:
                 w._refresh_router_reservations()
             return None
 
+    def try_reserve_in_flight(
+        self,
+        worker_id: str,
+        capability: Optional[str] = None,
+        model: Optional[str] = None,
+    ) -> Optional[str]:
+        """Atomically reserve a worker slot if it is still available.
+
+        Selection and dispatch are separate async operations. Without this
+        final locked check, two requests can both observe an idle swap-mode
+        worker and then race to load different LLMs on it.
+        """
+        with self._lock:
+            worker = self._workers.get(worker_id)
+            if worker is None:
+                return None
+            worker._refresh_router_reservations()
+            if not worker.has_capacity(capability=capability, model=model):
+                return None
+            return self.increment_in_flight(
+                worker_id,
+                1,
+                capability=capability,
+                model=model,
+            )
+
     def release_in_flight(self, worker_id: str, reservation_id: Optional[str]) -> None:
         """Release one tokenized dispatch lease; unreserved requests are no-ops."""
         if not reservation_id:

--- a/docker-compose-router.yml
+++ b/docker-compose-router.yml
@@ -29,7 +29,7 @@ services:
       # false = text/vision requests wait once every compatible node is busy.
       # true = after idle spillover, fill remaining parallel slots on busy nodes.
       - ROUTER_BUSY_SLOT_FALLBACK=${ROUTER_BUSY_SLOT_FALLBACK-false}
-      - ROUTER_PROMPT_AFFINITY_WAIT=${ROUTER_PROMPT_AFFINITY_WAIT:-2}
+      - ROUTER_PROMPT_AFFINITY_WAIT=${ROUTER_PROMPT_AFFINITY_WAIT:-15}
       # Optional managed text/vision overflow. When the key is set, Chutes is
       # advertised on the dashboard at t45 and used only after comparable or
       # faster internal workers are occupied.

--- a/ezlocalai/LLM.py
+++ b/ezlocalai/LLM.py
@@ -1194,6 +1194,9 @@ class LLM:
             "temperature": kwargs.get("temperature", self.params["temperature"]),
             "top_p": kwargs.get("top_p", self.params["top_p"]),
             "stream": stream,
+            # WorkConductor keeps its system/ability prefix byte-stable. Make
+            # prefix reuse explicit instead of relying on backend defaults.
+            "cache_prompt": True,
         }
         chat_request = self._apply_sampling_kwargs(chat_request, kwargs)
 

--- a/router_app.py
+++ b/router_app.py
@@ -3113,7 +3113,11 @@ def _prompt_affinity_wait_timeout() -> float:
     than waiting briefly for the worker that already owns its KV prefix. Keep
     the wait bounded so affinity never defeats worker failover.
     """
-    return max(0.0, _float_env("ROUTER_PROMPT_AFFINITY_WAIT", 2.0))
+    # Worker heartbeats can retain the just-finished request for several
+    # seconds after the router has released its own reservation. Spilling a
+    # 100k+ token continuation during that small reporting window throws away
+    # the hot KV prefix and costs far more than waiting for the cache owner.
+    return max(0.0, _float_env("ROUTER_PROMPT_AFFINITY_WAIT", 15.0))
 
 
 def _eligible_affinity_worker(
@@ -3538,6 +3542,7 @@ async def _proxy_via_tunnel(
     model: Optional[str] = None,
     stream_media_type: Optional[str] = None,
     stream_headers: Optional[Dict[str, str]] = None,
+    reservation_id: Optional[str] = None,
 ):
     """Route a request to a tunneled worker through its open WebSocket."""
     hub = get_tunnel_hub()
@@ -3559,9 +3564,10 @@ async def _proxy_via_tunnel(
             detail=f"Tunnel for worker {worker.label} ({wid}) is not connected",
         )
     registry = get_registry()
-    reservation_id = registry.increment_in_flight(
-        worker.worker_id, 1, capability=capability, model=model
-    )
+    if reservation_id is None:
+        reservation_id = registry.increment_in_flight(
+            worker.worker_id, 1, capability=capability, model=model
+        )
     request_timeout = timeout or float(getenv("REQUEST_TIMEOUT", "300"))
     try:
         status, resp_headers, chunks = await conn.request(
@@ -3631,6 +3637,7 @@ async def _proxy_json(
     model: Optional[str] = None,
     stream_media_type: Optional[str] = None,
     stream_headers: Optional[Dict[str, str]] = None,
+    reservation_id: Optional[str] = None,
 ):
     """Forward a JSON POST to a worker. Returns either a dict or a StreamingResponse."""
     payload = _worker_json_payload(worker, path, payload)
@@ -3648,6 +3655,7 @@ async def _proxy_json(
             model=model,
             stream_media_type=stream_media_type,
             stream_headers=stream_headers,
+            reservation_id=reservation_id,
         )
     url = f"{worker.url}{path}"
     timeout_seconds = timeout or float(getenv("REQUEST_TIMEOUT", "300"))
@@ -3666,9 +3674,10 @@ async def _proxy_json(
             connect=10,  # fail fast on connection errors, don't wait the full timeout
         )
     registry = get_registry()
-    reservation_id = registry.increment_in_flight(
-        worker.worker_id, 1, capability=capability, model=model
-    )
+    if reservation_id is None:
+        reservation_id = registry.increment_in_flight(
+            worker.worker_id, 1, capability=capability, model=model
+        )
 
     if not stream:
         try:
@@ -3775,13 +3784,15 @@ async def _iter_worker_stream_bytes(
     *,
     capability: Optional[str] = None,
     model: Optional[str] = None,
+    reservation_id: Optional[str] = None,
 ) -> AsyncIterator[bytes]:
     """Open one worker streaming request and yield raw SSE bytes."""
     payload = _worker_json_payload(worker, path, payload)
     registry = get_registry()
-    reservation_id = registry.increment_in_flight(
-        worker.worker_id, 1, capability=capability, model=model
-    )
+    if reservation_id is None:
+        reservation_id = registry.increment_in_flight(
+            worker.worker_id, 1, capability=capability, model=model
+        )
     timeout_seconds = float(getenv("REQUEST_TIMEOUT", "300"))
     try:
         if is_tunnel_url(worker.url):
@@ -3922,6 +3933,18 @@ async def _llm_stream_with_worker_failover(
                 f"could not pick another worker: {last_error}"
             )
             break
+        reservation_id = get_registry().try_reserve_in_flight(
+            worker.worker_id,
+            capability=capability,
+            model=model,
+        )
+        if reservation_id is None:
+            logging.info(
+                "[Router] worker %s lost an LLM dispatch race; selecting again",
+                worker.label,
+            )
+            await asyncio.sleep(0.05)
+            continue
         tried.add(worker.worker_id)
         assistant_seen = False
         pt = 0
@@ -3930,7 +3953,12 @@ async def _llm_stream_with_worker_failover(
         buf = b""
         retry_reason = ""
         stream = _iter_worker_stream_bytes(
-            worker, path, payload, capability=capability, model=model
+            worker,
+            path,
+            payload,
+            capability=capability,
+            model=model,
+            reservation_id=reservation_id,
         )
         try:
             async for chunk in stream:
@@ -4443,6 +4471,18 @@ async def _llm_proxy_with_retry(
             wait_indefinitely=wait_indefinitely,
             affinity_key=affinity_key,
         )
+        reservation_id = get_registry().try_reserve_in_flight(
+            worker.worker_id,
+            capability=capability,
+            model=model,
+        )
+        if reservation_id is None:
+            logging.info(
+                "[Router] worker %s lost an LLM dispatch race; selecting again",
+                worker.label,
+            )
+            await asyncio.sleep(0.05)
+            continue
         tried.add(worker.worker_id)
         try:
             resp = await _proxy_json(
@@ -4452,6 +4492,7 @@ async def _llm_proxy_with_retry(
                 stream=is_stream,
                 capability=capability,
                 model=model,
+                reservation_id=reservation_id,
             )
         except Exception as e:
             last_error = e

--- a/test_llm_streaming.py
+++ b/test_llm_streaming.py
@@ -53,6 +53,15 @@ class _FakeStreamingServer:
         return {}
 
 
+class _FakeChatServer:
+    def __init__(self):
+        self.request = None
+
+    def handle_chat_completions(self, request):
+        self.request = request
+        return {"choices": [{"message": {"content": "ok"}}]}
+
+
 def _fake_llm(chunks):
     llm = LLM.__new__(LLM)
     llm.server = _FakeStreamingServer(chunks)
@@ -61,6 +70,22 @@ def _fake_llm(chunks):
 
 
 class LlmStreamingTests(unittest.TestCase):
+    def test_chat_explicitly_enables_prompt_cache_reuse(self):
+        llm = LLM.__new__(LLM)
+        llm.server = _FakeChatServer()
+        llm.model_name = "test-model"
+        llm.system_message = ""
+        llm.params = {
+            "max_tokens": 128,
+            "temperature": 0.0,
+            "top_p": 1.0,
+            "stop": [],
+        }
+
+        llm.chat([{"role": "user", "content": "hello"}])
+
+        self.assertIs(llm.server.request["cache_prompt"], True)
+
     def test_long_context_mtp_auto_ubatch_is_memory_safe(self):
         fake_cuda = types.SimpleNamespace(
             is_available=lambda: True,

--- a/test_model_residency.py
+++ b/test_model_residency.py
@@ -7,7 +7,7 @@ import unittest
 from unittest import mock
 
 from Pipes import ModelType, Pipes
-from Router import WorkerInfo
+from Router import WorkerInfo, WorkerRegistry
 
 
 class LlmResidencyPolicyTests(unittest.TestCase):
@@ -147,6 +147,55 @@ class LlmDependencySlotTests(unittest.TestCase):
         }
 
         self.assertEqual(worker.slots_left(capability="image"), 0)
+
+
+class LlmSwapQueueTests(unittest.IsolatedAsyncioTestCase):
+    async def test_cross_model_request_waits_for_active_stream(self):
+        pipe = Pipes.__new__(Pipes)
+        pipe.llm_model_residency = "swap"
+        pipe._inference_count = 1
+        pipe._model_inference_counts = {"model-a": 1}
+        pipe._inference_count_lock = threading.Lock()
+
+        pending = asyncio.create_task(pipe._acquire_inference_slot("model-b"))
+        await asyncio.sleep(0.02)
+        self.assertFalse(pending.done())
+
+        pipe._decrement_inference_count("model-a")
+        await asyncio.wait_for(pending, timeout=0.5)
+
+        self.assertEqual(pipe._inference_count, 1)
+        self.assertEqual(pipe._model_inference_counts, {"model-b": 1})
+
+
+class RouterReservationTests(unittest.TestCase):
+    def test_atomic_reservation_blocks_cross_model_swap_race(self):
+        registry = WorkerRegistry(ttl_seconds=60, reservation_ttl_seconds=15)
+        registry.register(
+            WorkerInfo(
+                worker_id="worker",
+                label="worker",
+                url="http://worker.local",
+                capabilities=["text"],
+                models=["model-a", "model-b"],
+                cap_slots={"text": {"capacity": 1, "in_flight": 0, "queued": 0}},
+                model_slots={
+                    "model-a": {"capacity": 1, "in_flight": 0, "queued": 0},
+                    "model-b": {"capacity": 1, "in_flight": 0, "queued": 0},
+                },
+                extra={"llm_model_residency": "swap"},
+            )
+        )
+
+        first = registry.try_reserve_in_flight(
+            "worker", capability="text", model="model-a"
+        )
+        second = registry.try_reserve_in_flight(
+            "worker", capability="text", model="model-b"
+        )
+
+        self.assertIsNotNone(first)
+        self.assertIsNone(second)
 
 
 class ImageHandoffTests(unittest.IsolatedAsyncioTestCase):

--- a/test_router_streaming.py
+++ b/test_router_streaming.py
@@ -19,6 +19,11 @@ def _sse(payload: str) -> bytes:
 
 
 class RouterStreamingTests(unittest.IsolatedAsyncioTestCase):
+    def test_prompt_affinity_wait_default_covers_worker_heartbeat_release_lag(self):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("ROUTER_PROMPT_AFFINITY_WAIT", None)
+            self.assertEqual(router_app._prompt_affinity_wait_timeout(), 15.0)
+
     async def test_prompt_affinity_reuses_the_same_available_worker(self):
         registry = WorkerRegistry(ttl_seconds=60)
         first = registry.register(
@@ -206,24 +211,30 @@ class RouterStreamingTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(info["error_message"], "request exceeds context")
 
     async def test_stream_failover_retries_empty_worker_before_text(self):
-        first = WorkerInfo(
-            worker_id="first",
-            label="first",
-            url="http://first",
-            capabilities=["text"],
-            models=["model"],
+        registry = WorkerRegistry(ttl_seconds=60)
+        first = registry.register(
+            WorkerInfo(
+                worker_id="first",
+                label="first",
+                url="http://first",
+                capabilities=["text"],
+                models=["model"],
+            )
         )
-        second = WorkerInfo(
-            worker_id="second",
-            label="second",
-            url="http://second",
-            capabilities=["text"],
-            models=["model"],
+        second = registry.register(
+            WorkerInfo(
+                worker_id="second",
+                label="second",
+                url="http://second",
+                capabilities=["text"],
+                models=["model"],
+            )
         )
         workers = [first, second]
         original_pick = router_app._pick
         original_iter = router_app._iter_worker_stream_bytes
         original_attempts = router_app._stream_max_attempts
+        original_registry = router_app.get_registry
 
         async def fake_pick(capability, model, exclude=None, **kwargs):
             for worker in workers:
@@ -231,7 +242,15 @@ class RouterStreamingTests(unittest.IsolatedAsyncioTestCase):
                     return worker
             raise AssertionError("no fake worker left")
 
-        async def fake_iter(worker, path, payload, *, capability=None, model=None):
+        async def fake_iter(
+            worker,
+            path,
+            payload,
+            *,
+            capability=None,
+            model=None,
+            reservation_id=None,
+        ):
             if worker.worker_id == "first":
                 yield _sse(
                     '{"error":{"message":"request exceeds context","type":"exceed_context_size_error"}}'
@@ -244,6 +263,7 @@ class RouterStreamingTests(unittest.IsolatedAsyncioTestCase):
             router_app._pick = fake_pick
             router_app._iter_worker_stream_bytes = fake_iter
             router_app._stream_max_attempts = lambda capability, *args: 2
+            router_app.get_registry = lambda: registry
 
             chunks = []
             async for chunk in router_app._llm_stream_with_worker_failover(
@@ -258,6 +278,7 @@ class RouterStreamingTests(unittest.IsolatedAsyncioTestCase):
             router_app._pick = original_pick
             router_app._iter_worker_stream_bytes = original_iter
             router_app._stream_max_attempts = original_attempts
+            router_app.get_registry = original_registry
 
         body = b"".join(chunks).decode("utf-8")
         self.assertIn('"content":"ok"', body)


### PR DESCRIPTION
## Summary
- enable llama.cpp prompt caching on chat requests
- wait up to 15 seconds for the worker that owns a hot prompt prefix before spilling a continuation to another GPU
- atomically reserve router capacity after worker selection so concurrent requests cannot both dispatch to the same idle swap-mode worker
- queue a cross-model request inside a swap-mode worker until the active model stream has actually finished instead of returning HTTP 500
- document the affinity wait default and update router compose configuration

## Root cause
Worker selection and in-flight reservation were separate operations. Two requests could both observe a swap-mode worker as idle before either reservation became visible, then attempt different configured models concurrently. The second request failed with `Cannot switch LLMs while another configured model is in use`. Streaming made this more visible because the HTTP request could be handed off before the generator had released its model slot.

The router now performs the final capacity check and reservation under one registry lock. The worker also treats cross-model contention as a queue condition, retaining its current model until the active stream finishes.

## Verification
- `python -m black Pipes.py Router.py router_app.py ezlocalai/LLM.py test_llm_streaming.py test_model_residency.py test_router_streaming.py`
- `python -m unittest test_router_streaming.py test_llm_streaming.py test_model_residency.py`: 35 passed
- rebuilt `docker-compose-cuda.yml`; worker healthy with Qwen3.8-27B resident and prompt cache enabled
- rebuilt `docker-compose-router.yml`; router healthy
- verified the worker continues heartbeating in the live `.214` router pool alongside the 4090 and 5090 workers

Paired WorkConductor prompt-prefix, continuation compaction, and activity hydration changes: https://github.com/Josh-XT/WorkConductor/pull/170