### PR TITLE
Preserve parent prompt caches during browser planning

### DIFF
--- a/router_app.py
+++ b/router_app.py
@@ -3141,6 +3141,65 @@ def _eligible_affinity_worker(
     )
 
 
+def _prompt_cache_avoid_worker_ids(
+    payload: Dict[str, Any],
+    capability: str,
+    model: Optional[str],
+    excluded: Optional[set] = None,
+) -> set:
+    """Softly avoid workers that own a nested request's parent KV cache.
+
+    Nested browser planners replace most of their prompt on each page step. If
+    they run on the worker holding a paused long-horizon conversation, that
+    small request can evict a 100k+ token prefix. Avoidance is only applied
+    when another compatible worker exists, so single-worker deployments retain
+    normal behavior.
+    """
+    raw = payload.get("prompt_cache_avoid_key")
+    if not isinstance(raw, str) or not raw.strip():
+        return set()
+
+    _prune_prompt_affinity(time.time())
+    avoid_key = _prompt_affinity_key({"prompt_cache_key": raw}, capability, model)
+    avoid_worker_id = (
+        _prompt_affinity.get(avoid_key, (None, 0.0))[0] if avoid_key else None
+    )
+    if not avoid_worker_id:
+        return set()
+
+    hard_excluded = set(excluded or ())
+    avoided = {avoid_worker_id}
+    tunnel_hub = get_tunnel_hub()
+    has_alternative = any(
+        worker.worker_id not in avoided
+        and _eligible_affinity_worker(
+            worker, capability, model, hard_excluded | avoided
+        )
+        and worker.has_capacity(capability, model)
+        and (
+            not is_tunnel_url(worker.url)
+            or tunnel_hub.is_connected(worker_id_from_tunnel_url(worker.url))
+        )
+        for worker in get_registry().list_workers(alive_only=True)
+    )
+    if has_alternative:
+        logging.info(
+            "[Router] nested prompt will avoid parent cache worker %s "
+            "(model=%r, cap=%s)",
+            avoid_worker_id,
+            model,
+            capability,
+        )
+        return avoided
+    logging.info(
+        "[Router] nested prompt shares its parent cache worker because no "
+        "compatible alternative is available (model=%r, cap=%s)",
+        model,
+        capability,
+    )
+    return set()
+
+
 async def _pick(
     capability: str,
     model: Optional[str] = None,
@@ -3441,6 +3500,7 @@ def _worker_json_payload(
     # Router-only metadata. Local and external OpenAI-compatible workers do
     # not need to know how affinity was selected.
     forwarded.pop("prompt_cache_key", None)
+    forwarded.pop("prompt_cache_avoid_key", None)
     if not worker.external_fallback:
         return forwarded
 
@@ -3914,6 +3974,9 @@ async def _llm_stream_with_worker_failover(
 ) -> AsyncIterator[bytes]:
     tried: set = set()
     affinity_key = _prompt_affinity_key(payload, capability, model)
+    cache_avoid_worker_ids = _prompt_cache_avoid_worker_ids(
+        payload, capability, model, tried
+    )
     max_attempts = _stream_max_attempts(capability, external_fallback_allowed)
     last_error = ""
     for attempt in range(max_attempts):
@@ -3921,7 +3984,7 @@ async def _llm_stream_with_worker_failover(
             worker = await _pick(
                 capability,
                 model,
-                exclude=tried,
+                exclude=tried | (cache_avoid_worker_ids if attempt == 0 else set()),
                 external_fallback_allowed=external_fallback_allowed,
                 wait_indefinitely=wait_indefinitely,
                 affinity_key=affinity_key,
@@ -4458,6 +4521,9 @@ async def _llm_proxy_with_retry(
 
     tried: set = set()
     affinity_key = _prompt_affinity_key(payload, capability, model)
+    cache_avoid_worker_ids = _prompt_cache_avoid_worker_ids(
+        payload, capability, model, tried
+    )
     last_error: Optional[Exception] = None
     last_status: Optional[int] = None
     max_attempts = 1 + _max_retries()
@@ -4466,7 +4532,7 @@ async def _llm_proxy_with_retry(
         worker = await _pick(
             capability,
             model,
-            exclude=tried,
+            exclude=tried | (cache_avoid_worker_ids if attempt == 0 else set()),
             external_fallback_allowed=external_fallback_allowed,
             wait_indefinitely=wait_indefinitely,
             affinity_key=affinity_key,

--- a/test_router_streaming.py
+++ b/test_router_streaming.py
@@ -151,6 +151,74 @@ class RouterStreamingTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(router_app._prompt_affinity[affinity_key][0], "first")
         self.assertEqual(router.wait_for_worker.await_count, 2)
 
+    def test_nested_prompt_softly_avoids_parent_cache_worker(self):
+        registry = WorkerRegistry(ttl_seconds=60)
+        registry.register(
+            WorkerInfo(
+                worker_id="parent",
+                label="parent",
+                url="http://parent",
+                capabilities=["text"],
+                models=["model"],
+            )
+        )
+        registry.register(
+            WorkerInfo(
+                worker_id="browser",
+                label="browser",
+                url="http://browser",
+                capabilities=["text"],
+                models=["model"],
+            )
+        )
+        router_app._prompt_affinity.clear()
+        parent_key = router_app._prompt_affinity_key(
+            {"prompt_cache_key": "workconductor:agent:conversation"},
+            "text",
+            "model",
+        )
+        router_app._prompt_affinity[parent_key] = ("parent", router_app.time.time())
+
+        with patch("router_app.get_registry", return_value=registry):
+            avoided = router_app._prompt_cache_avoid_worker_ids(
+                {
+                    "prompt_cache_key": "workconductor-browser:agent:conversation",
+                    "prompt_cache_avoid_key": "workconductor:agent:conversation",
+                },
+                "text",
+                "model",
+            )
+
+        self.assertEqual(avoided, {"parent"})
+
+    def test_nested_prompt_does_not_avoid_only_compatible_worker(self):
+        registry = WorkerRegistry(ttl_seconds=60)
+        registry.register(
+            WorkerInfo(
+                worker_id="parent",
+                label="parent",
+                url="http://parent",
+                capabilities=["text"],
+                models=["model"],
+            )
+        )
+        router_app._prompt_affinity.clear()
+        parent_key = router_app._prompt_affinity_key(
+            {"prompt_cache_key": "workconductor:agent:conversation"},
+            "text",
+            "model",
+        )
+        router_app._prompt_affinity[parent_key] = ("parent", router_app.time.time())
+
+        with patch("router_app.get_registry", return_value=registry):
+            avoided = router_app._prompt_cache_avoid_worker_ids(
+                {"prompt_cache_avoid_key": "workconductor:agent:conversation"},
+                "text",
+                "model",
+            )
+
+        self.assertEqual(avoided, set())
+
     def test_llamacpp_timings_report_total_cached_and_evaluated_prompt_tokens(self):
         timings = {}
 
@@ -193,10 +261,15 @@ class RouterStreamingTests(unittest.IsolatedAsyncioTestCase):
         forwarded = router_app._worker_json_payload(
             worker,
             "/v1/chat/completions",
-            {"model": "model", "prompt_cache_key": "conversation-key"},
+            {
+                "model": "model",
+                "prompt_cache_key": "conversation-key",
+                "prompt_cache_avoid_key": "parent-key",
+            },
         )
 
         self.assertNotIn("prompt_cache_key", forwarded)
+        self.assertNotIn("prompt_cache_avoid_key", forwarded)
         self.assertEqual(forwarded["model"], "model")
 
     def test_sse_classifier_detects_nested_error(self):


### PR DESCRIPTION
## Summary
- recognize nested WorkConductor browser cache keys and their parent conversation cache owner
- avoid scheduling browser planner inference on the parent cache worker when another compatible worker is available
- fall back safely to the parent worker when it is the only compatible worker
- strip router-only scheduling metadata before forwarding requests to workers

## Why
Rendered browser automation is a nested inference workload. Sending it to the worker that owns the parent conversation evicts or replaces the large Qwen prompt cache, making the next agent continuation reread up to roughly 190k tokens. This keeps nested browser work on another one of the available compatible GPUs without sacrificing availability.

## Related WorkConductor change
- Josh-XT/WorkConductor#178

## Tests
- `pytest -q test_router_streaming.py` (14 passed)
- `python -m py_compile router_app.py test_router_streaming.py`
- `black --check router_app.py test_router_streaming.py`