### PR TITLE
Prevent concurrent context allocation failures

### DIFF
--- a/Pipes.py
+++ b/Pipes.py
@@ -5066,7 +5066,10 @@ class Pipes:
                 logging.error(
                     f"[LLM] CPU fallback also failed for {model_name}: {last_error}"
                 )
-                raise last_error
+                raise RuntimeError(
+                    "Failed to allocate inference capacity for "
+                    f"{model_name} at n_ctx={max_tokens}: {last_error}"
+                ) from last_error
 
             # The last binary-search probe failed above the best known result, so
             # reload that exact maximum once after clearing the failed context.
@@ -9015,6 +9018,35 @@ class Pipes:
 
         return max(1, n_parallel)
 
+    def _inference_capacity_for_model(self, model_name: Optional[str]) -> int:
+        """Return the number of native slots that can serve a public model name."""
+        if not model_name:
+            return 1
+
+        capacity = 0
+        for model_id in getattr(self, "available_models", []):
+            if self._resolve_source_model(model_id) != model_name:
+                continue
+            instance = getattr(self, "persistent_llms", {}).get(model_id)
+            capacity += self._resolved_parallel_for_model(model_id, inst=instance)
+
+        if getattr(self, "llm_model_residency", "resident") == "swap":
+            return min(1, capacity) if capacity > 0 else 1
+        return max(1, capacity)
+
+    def _configured_context_limit_for_model(
+        self, model_id: Optional[str] = None
+    ) -> int:
+        """Return the configured hard context ceiling for a model instance."""
+        model_id = model_id or self.current_llm_name
+        model_configs = getattr(self, "model_configs", {})
+        config = model_configs.get(model_id, {}) if model_id else {}
+        try:
+            configured = int(config.get("max_tokens", self._optimal_context) or 0)
+        except (TypeError, ValueError):
+            configured = int(self._optimal_context or 0)
+        return max(1, configured or int(self._optimal_context or 16384))
+
     def get_text_queue_capacity(self) -> int:
         """Return the automatic local text request queue capacity."""
         snapshot = self.get_slot_capacity_snapshot()
@@ -9289,7 +9321,7 @@ class Pipes:
             )
 
     async def _acquire_inference_slot(self, model_name: Optional[str] = None):
-        """Register an inference, waiting before a swap across active models."""
+        """Register an inference after a real native model slot is available."""
         waiting_for = None
         while True:
             with self._inference_count_lock:
@@ -9301,8 +9333,13 @@ class Pipes:
                     for name, count in self._model_inference_counts.items()
                     if count > 0 and name != model_name
                 }
-                if not handoff_active and (
-                    self.llm_model_residency != "swap" or not conflicts
+                model_in_flight = self._model_inference_counts.get(model_name, 0)
+                model_capacity = self._inference_capacity_for_model(model_name)
+                model_slot_available = model_in_flight < model_capacity
+                if (
+                    not handoff_active
+                    and model_slot_available
+                    and (self.llm_model_residency != "swap" or not conflicts)
                 ):
                     self._inference_count += 1
                     if model_name:
@@ -9314,10 +9351,19 @@ class Pipes:
                         self._inference_count,
                     )
                     return
-            wait_reason = {"shared_gpu_handoff": 1} if handoff_active else conflicts
+            if handoff_active:
+                wait_reason = {"shared_gpu_handoff": 1}
+            elif not model_slot_available:
+                wait_reason = {
+                    "model": model_name or "default",
+                    "in_flight": model_in_flight,
+                    "capacity": model_capacity,
+                }
+            else:
+                wait_reason = conflicts
             if wait_reason != waiting_for:
                 logging.info(
-                    "[LLM Residency] Waiting to use %s while %s finishes",
+                    "[LLM Slots] Waiting to use %s while %s finishes",
                     model_name,
                     wait_reason,
                 )
@@ -10132,6 +10178,15 @@ class Pipes:
                     messages_or_prompt, "chat" if chat_mode else "completion"
                 )
                 required_context = calculate_context_size(estimated_tokens)
+                configured_context_limit = self._configured_context_limit_for_model()
+                if required_context > configured_context_limit:
+                    logging.info(
+                        "[LLM] Streaming estimate requested %s context tokens; "
+                        "clamping allocation to configured model limit %s",
+                        f"{required_context:,}",
+                        f"{configured_context_limit:,}",
+                    )
+                    required_context = configured_context_limit
 
                 logging.debug(
                     f"[LLM] Streaming pre-check: estimated {estimated_tokens:,} tokens, "
@@ -10201,7 +10256,10 @@ class Pipes:
                                 needed_tokens = current_context * 2
 
                         # Calculate new context: actual tokens needed + 16k headspace
-                        new_context = calculate_context_size(needed_tokens)
+                        new_context = min(
+                            calculate_context_size(needed_tokens),
+                            self._configured_context_limit_for_model(),
+                        )
 
                         if new_context > current_context:
                             if not context_reload_can_help(
@@ -10470,7 +10528,10 @@ class Pipes:
                         )
                         # Pre-load larger context for next request
                         if needed_tokens > 0:
-                            new_context = calculate_context_size(needed_tokens)
+                            new_context = min(
+                                calculate_context_size(needed_tokens),
+                                pipes_self._configured_context_limit_for_model(),
+                            )
                             current_context = pipes_self.current_context or 16384
                             if context_reload_can_help(
                                 error_msg, current_context, new_context

--- a/README.md
+++ b/README.md
@@ -246,6 +246,12 @@ LLM_BATCH_SIZE=auto
 LLM_UBATCH_SIZE=auto
 ```
 
+Single-GPU NVIDIA workers can also A/B test llama.cpp's experimental concurrent
+CUDA-stream optimization with `GGML_CUDA_GRAPH_OPT=1`. It primarily targets
+token-generation throughput rather than prompt processing. Results vary by GPU
+and model, so leave it disabled unless a representative decode benchmark shows
+a repeatable improvement.
+
 Higher MTP draft lengths can substantially accelerate copy-heavy output but
 may slow novel generation and consume more VRAM. Explicit `LLM_UBATCH_SIZE`
 values are attempted first; the resilient loader retries smaller physical

--- a/app.py
+++ b/app.py
@@ -36,6 +36,7 @@ import time
 import asyncio
 from pathlib import Path
 from Globals import getenv
+from ezlocalai.context_retry import classify_inference_capacity_error
 from ezlocalai.MUSIC import (
     ACE_STEP_DEFAULT_BPM,
     ACE_STEP_DEFAULT_GUIDANCE_SCALE,
@@ -139,6 +140,25 @@ def _sync_request_queue_capacity() -> Dict[str, Any]:
 
 
 _sync_request_queue_capacity()
+
+
+def _inference_failure_http_exception(error: Exception) -> Optional[HTTPException]:
+    """Translate actionable inference capacity failures into stable API errors."""
+    classified = classify_inference_capacity_error(str(error or "Inference failed"))
+    if classified is None:
+        return None
+
+    detail = classified["detail"]
+    if detail["type"] == "inference_capacity_error":
+        context_tokens = int(
+            getattr(pipe, "current_context", 0)
+            or getattr(pipe, "_optimal_context", 0)
+            or 0
+        )
+        if context_tokens > 0:
+            detail["n_ctx"] = context_tokens
+    return HTTPException(status_code=classified["status_code"], detail=detail)
+
 
 app = FastAPI(title="ezlocalai Server", docs_url="/")
 app.add_middleware(
@@ -655,6 +675,9 @@ async def chat_completions(
             )
         except Exception as e:
             logging.error(f"[Chat Completions] Unexpected error: {e}")
+            actionable_error = _inference_failure_http_exception(e)
+            if actionable_error is not None:
+                raise actionable_error
             raise HTTPException(status_code=500, detail="Internal server error")
 
         if audio_response:

--- a/docker-compose-cuda.yml
+++ b/docker-compose-cuda.yml
@@ -63,6 +63,9 @@ services:
       - QUANT_TYPE=${QUANT_TYPE:-Q3_K_XL}
       - MTP_SPEC_DRAFT_P_MIN=${MTP_SPEC_DRAFT_P_MIN:-auto}
       - MTP_SPEC_DRAFT_N_MAX=${MTP_SPEC_DRAFT_N_MAX:-auto}
+      # Experimental llama.cpp concurrent-stream optimization for single-GPU
+      # token generation. Keep opt-in because the gain is GPU/model specific.
+      - GGML_CUDA_GRAPH_OPT=${GGML_CUDA_GRAPH_OPT:-0}
       - CUDA_DOCKER_ARCH=all
       - TENSOR_SPLIT=${TENSOR_SPLIT:-}
       - TOKENIZERS_PARALLELISM=false

--- a/ezlocalai/context_retry.py
+++ b/ezlocalai/context_retry.py
@@ -1,6 +1,16 @@
 import re
 
 
+_MEMORY_CAPACITY_MARKERS = (
+    "out of memory",
+    "cuda out of memory",
+    "failed to allocate",
+    "alloc_buffer",
+    "cudamalloc",
+    "insufficient memory",
+)
+
+
 def parse_context_error_limits(error_msg: str) -> tuple[int, int]:
     """Extract prompt token count and actual n_ctx from llama.cpp errors."""
     text = str(error_msg or "")
@@ -16,6 +26,36 @@ def parse_context_error_limits(error_msg: str) -> tuple[int, int]:
     prompt_tokens = int(prompt_match.group(1)) if prompt_match else 0
     actual_context = int(ctx_match.group(1)) if ctx_match else 0
     return prompt_tokens, actual_context
+
+
+def classify_inference_capacity_error(error_msg: str) -> dict | None:
+    """Return structured recovery metadata for actionable capacity failures."""
+    message = str(error_msg or "Inference failed")
+    prompt_tokens, context_tokens = parse_context_error_limits(message)
+    if prompt_tokens > 0 and context_tokens > 0:
+        return {
+            "status_code": 413,
+            "detail": {
+                "type": "context_capacity_error",
+                "message": message,
+                "n_prompt_tokens": prompt_tokens,
+                "n_ctx": context_tokens,
+                "compact_and_retry": True,
+            },
+        }
+
+    lowered = message.lower()
+    if any(marker in lowered for marker in _MEMORY_CAPACITY_MARKERS):
+        return {
+            "status_code": 503,
+            "detail": {
+                "type": "inference_capacity_error",
+                "message": message,
+                "compact_and_retry": True,
+            },
+        }
+
+    return None
 
 
 def context_reload_can_help(

--- a/test_context_retry.py
+++ b/test_context_retry.py
@@ -1,12 +1,41 @@
 import unittest
 
 from ezlocalai.context_retry import (
+    classify_inference_capacity_error,
     context_reload_can_help,
     parse_context_error_limits,
 )
 
 
 class ContextRetryTests(unittest.TestCase):
+    def test_classify_context_capacity_error(self):
+        error = (
+            "request (264165 tokens) exceeds the available context size "
+            "(262144 tokens) [n_prompt_tokens=264165, n_ctx=262144]"
+        )
+
+        classified = classify_inference_capacity_error(error)
+
+        self.assertEqual(classified["status_code"], 413)
+        self.assertEqual(classified["detail"]["type"], "context_capacity_error")
+        self.assertEqual(classified["detail"]["n_prompt_tokens"], 264165)
+        self.assertEqual(classified["detail"]["n_ctx"], 262144)
+        self.assertTrue(classified["detail"]["compact_and_retry"])
+
+    def test_classify_gpu_memory_capacity_error(self):
+        classified = classify_inference_capacity_error(
+            "CUDA error: out of memory while cudaMalloc attempted 248 MiB"
+        )
+
+        self.assertEqual(classified["status_code"], 503)
+        self.assertEqual(classified["detail"]["type"], "inference_capacity_error")
+        self.assertTrue(classified["detail"]["compact_and_retry"])
+
+    def test_generic_model_initialization_error_is_not_retryable_capacity(self):
+        self.assertIsNone(
+            classify_inference_capacity_error("failed to init server: invalid model")
+        )
+
     def test_parse_context_error_limits_from_llama_cpp_error(self):
         error = (
             "request (264165 tokens) exceeds the available context size "

--- a/test_model_residency.py
+++ b/test_model_residency.py
@@ -1,10 +1,13 @@
 import asyncio
 import os
+import sys
 import threading
 import time
 import types
 import unittest
 from unittest import mock
+
+sys.modules.setdefault("xllamacpp", types.SimpleNamespace())
 
 from Pipes import ModelType, Pipes, _VoiceSlotGuard
 from Router import WorkerInfo, WorkerRegistry
@@ -212,6 +215,49 @@ class VoiceHandoffTests(unittest.IsolatedAsyncioTestCase):
 
 
 class LlmSwapQueueTests(unittest.IsolatedAsyncioTestCase):
+    @staticmethod
+    def _resident_pipe(n_parallel=1):
+        pipe = Pipes.__new__(Pipes)
+        pipe.llm_model_residency = "resident"
+        pipe.available_models = ["model-a"]
+        pipe.model_sources = {"model-a": "model-a"}
+        pipe.model_configs = {
+            "model-a": {"n_parallel": n_parallel, "max_tokens": 262144}
+        }
+        pipe.persistent_llms = {"model-a": types.SimpleNamespace(n_parallel=n_parallel)}
+        pipe._inference_count = 1
+        pipe._model_inference_counts = {"model-a": 1}
+        pipe._inference_count_lock = threading.Lock()
+        return pipe
+
+    async def test_same_model_request_waits_when_native_slot_is_full(self):
+        pipe = self._resident_pipe(n_parallel=1)
+
+        pending = asyncio.create_task(pipe._acquire_inference_slot("model-a"))
+        await asyncio.sleep(0.02)
+        self.assertFalse(pending.done())
+
+        pipe._decrement_inference_count("model-a")
+        await asyncio.wait_for(pending, timeout=0.5)
+
+        self.assertEqual(pipe._inference_count, 1)
+        self.assertEqual(pipe._model_inference_counts, {"model-a": 1})
+
+    async def test_same_model_request_uses_an_available_parallel_slot(self):
+        pipe = self._resident_pipe(n_parallel=2)
+
+        await asyncio.wait_for(pipe._acquire_inference_slot("model-a"), timeout=0.5)
+
+        self.assertEqual(pipe._inference_count, 2)
+        self.assertEqual(pipe._model_inference_counts, {"model-a": 2})
+
+    def test_configured_context_limit_is_a_hard_ceiling(self):
+        pipe = self._resident_pipe(n_parallel=1)
+        pipe.current_llm_name = "model-a"
+        pipe._optimal_context = 200000
+
+        self.assertEqual(pipe._configured_context_limit_for_model(), 262144)
+
     async def test_cross_model_request_waits_for_active_stream(self):
         pipe = Pipes.__new__(Pipes)
         pipe.llm_model_residency = "swap"


### PR DESCRIPTION
## Summary
- gate local LLM inference by the model's real native slot capacity so a lazy streaming response cannot release the queue into a concurrent same-model context reload
- clamp adaptive context allocation to the configured model ceiling and preserve actionable OOM/context details as structured 413/503 responses
- include the opt-in CUDA graph optimization setting and documentation for representative decode benchmarking

## Why
The attached 5090 logs showed a 200k+ token stream still prefilling while a second request entered the same `N_PARALLEL=1` model. The second request attempted a destructive context reload, rounded its allocation above the configured/model context ceiling, and exhausted the roughly 1 GB of VRAM that remained at failure time. The later 4.7 GB free reading was after the failed model servers unwound.

## Verification
- `python -m black --check Pipes.py app.py ezlocalai/context_retry.py test_context_retry.py test_model_residency.py`
- `python -m unittest discover -p 'test_*.py'` (210 passed, 1 skipped)
- rebuilt with `docker compose -f docker-compose-cuda.yml down && docker compose -f docker-compose-cuda.yml up -d --build`
- `GET /health` returned `{"status":"healthy"}`
- resource diagnostics reported one local text/model slot for `N_PARALLEL=1`
