### PR TITLE
Harden shared GPU TTS streaming lifecycle

### DIFF
--- a/Pipes.py
+++ b/Pipes.py
@@ -3967,8 +3967,8 @@ class _VoiceSlotGuard:
         self._semaphore = asyncio.Semaphore(max(1, int(capacity or 1)))
         self._states: Dict[Any, List[Dict[str, Any]]] = {}
 
-    async def __aenter__(self):
-        key = self.pipe._lease_key()
+    async def acquire(self) -> Dict[str, Any]:
+        """Acquire a voice lease that may be released from another ASGI task."""
         should_handoff = self.pipe._voice_should_unload_llm(self.service)
         state: Dict[str, Any] = {
             "handoff": should_handoff,
@@ -3993,8 +3993,7 @@ class _VoiceSlotGuard:
 
             await self._semaphore.acquire()
             state["semaphore"] = True
-            self._states.setdefault(key, []).append(state)
-            return self
+            return state
         except Exception:
             try:
                 if should_handoff and state.get("handoff_state"):
@@ -4016,13 +4015,11 @@ class _VoiceSlotGuard:
                     self.pipe._voice_handoff_lock.release()
             raise
 
-    async def __aexit__(self, exc_type, exc_value, traceback):
-        key = self.pipe._lease_key()
-        stack = self._states.get(key, [])
-        state = stack.pop() if stack else {}
-        if not stack:
-            self._states.pop(key, None)
-
+    async def release(self, state: Optional[Dict[str, Any]]) -> None:
+        state = state or {}
+        if state.get("released"):
+            return
+        state["released"] = True
         try:
             if state.get("handoff"):
                 # The endpoint normally releases its lease first. Force a final
@@ -4048,6 +4045,20 @@ class _VoiceSlotGuard:
                 self._semaphore.release()
             if state.get("shared_lock"):
                 self.pipe._voice_handoff_lock.release()
+
+    async def __aenter__(self):
+        key = self.pipe._lease_key()
+        state = await self.acquire()
+        self._states.setdefault(key, []).append(state)
+        return self
+
+    async def __aexit__(self, exc_type, exc_value, traceback):
+        key = self.pipe._lease_key()
+        stack = self._states.get(key, [])
+        state = stack.pop() if stack else {}
+        if not stack:
+            self._states.pop(key, None)
+        await self.release(state)
         return False
 
 

--- a/README.md
+++ b/README.md
@@ -720,9 +720,11 @@ instances are available on a dedicated voice worker. A mixed LLM/voice worker
 defaults to `VOICE_UNLOAD_LLM_DURING_GENERATION=auto`: TTS and STT do not stay
 warm beside the LLM. The router treats them as one shared worker slot, waits for
 active LLM work to finish, temporarily unloads the LLM, runs the voice request,
-then unloads the voice model and restores the prior LLM residency. TTS and STT
-also exclude one another during this handoff. Set the option to `false` only when
-the worker has enough independent GPU capacity to keep voice models resident.
+then unloads the voice model and restores prior LLM availability. The LLM is
+reloaded eagerly only when configured below; otherwise the next text request
+loads it lazily. TTS and STT also exclude one another during this handoff. Set
+the option to `false` only when the worker has enough independent GPU capacity
+to keep voice models resident.
 
 `VOICE_WAIT_FOR_LLM_IDLE_TIMEOUT=60` controls the local race-safety timeout, and
 `VOICE_RELOAD_LLM_AFTER_GENERATION=false` controls eager restoration. It defaults

--- a/app.py
+++ b/app.py
@@ -1694,19 +1694,29 @@ async def text_to_speech_stream(tts: TextToSpeech, user=Depends(verify_api_key))
             },
         )
 
+    # Acquire the shared GPU slot and load TTS before committing HTTP 200.
+    # StreamingResponse runs its iterator in a separate ASGI task, so transfer
+    # the explicit lease instead of relying on task-local context-manager state.
+    tts_lease = await pipe._tts_lock.acquire()
+    try:
+        tts_model = pipe._get_tts()
+    except Exception:
+        await pipe._tts_lock.release(tts_lease)
+        raise
+
     async def audio_stream_generator():
-        async with pipe._tts_lock:
-            tts_model = pipe._get_tts()
-            try:
-                async for chunk in tts_model.generate_stream(
-                    text=tts.input, voice=tts.voice, language=tts.language
-                ):
-                    yield chunk
-            finally:
-                pipe.resource_manager.mark_model_in_use(ModelType.TTS, False)
-                # In voice server mode, don't destroy TTS - keep it loaded
-                if not is_voice_server_mode():
-                    pipe._destroy_tts()
+        try:
+            async for chunk in tts_model.generate_stream(
+                text=tts.input, voice=tts.voice, language=tts.language
+            ):
+                yield chunk
+        finally:
+            pipe.resource_manager.mark_model_in_use(ModelType.TTS, False)
+            # The handoff lease performs ordered cleanup before restoring the
+            # LLM. Dedicated/non-handoff voice workers retain prior behavior.
+            if not is_voice_server_mode() and not tts_lease.get("handoff"):
+                pipe._destroy_tts()
+            await pipe._tts_lock.release(tts_lease)
 
     return StreamingResponse(
         audio_stream_generator(),

--- a/router_app.py
+++ b/router_app.py
@@ -3701,6 +3701,19 @@ async def _proxy_via_tunnel(
         finally:
             registry.release_in_flight(worker.worker_id, reservation_id)
 
+    if status >= 400:
+        try:
+            buf = bytearray()
+            async for c in chunks:
+                buf.extend(c)
+            return Response(
+                content=bytes(buf),
+                status_code=status,
+                media_type=media_type or "application/json",
+            )
+        finally:
+            registry.release_in_flight(worker.worker_id, reservation_id)
+
     async def gen():
         sent_any = False
         try:
@@ -3711,16 +3724,17 @@ async def _proxy_via_tunnel(
             logging.warning(
                 f"[Router] Tunnel stream from {worker.label}{path} failed: {e}"
             )
-            error = {
-                "error": {
-                    "message": (
-                        f"Worker stream failed after proxying {int(sent_any)} chunk(s): "
-                        f"{type(e).__name__}: {e}"
-                    ),
-                    "type": "worker_stream_error",
+            if (stream_media_type or media_type or "").startswith("text/event-stream"):
+                error = {
+                    "error": {
+                        "message": (
+                            f"Worker stream failed after proxying {int(sent_any)} chunk(s): "
+                            f"{type(e).__name__}: {e}"
+                        ),
+                        "type": "worker_stream_error",
+                    }
                 }
-            }
-            yield f"data: {json.dumps(error)}\n\n".encode("utf-8")
+                yield f"data: {json.dumps(error)}\n\n".encode("utf-8")
         finally:
             registry.release_in_flight(worker.worker_id, reservation_id)
 
@@ -3806,12 +3820,39 @@ async def _proxy_json(
         finally:
             registry.release_in_flight(worker.worker_id, reservation_id)
 
+    # Open the upstream request before committing downstream stream headers so
+    # worker setup failures retain their real HTTP status and JSON body.
+    session = aiohttp.ClientSession(timeout=request_timeout)
+    try:
+        resp = await session.post(url, json=payload, headers=headers)
+    except Exception as e:
+        await session.close()
+        registry.release_in_flight(worker.worker_id, reservation_id)
+        logging.warning(f"[Router] Stream setup from {worker.url}{path} failed: {e}")
+        registry.record_connection_failure(worker.worker_id)
+        registry.record_error(
+            worker.worker_id,
+            kind="connection",
+            path=path,
+            message=f"{type(e).__name__}: {e}",
+        )
+        raise
+
+    if resp.status >= 400:
+        try:
+            body = await resp.read()
+            media_type = resp.headers.get("Content-Type", "application/json")
+            return Response(
+                content=body, status_code=resp.status, media_type=media_type
+            )
+        finally:
+            resp.release()
+            await session.close()
+            registry.release_in_flight(worker.worker_id, reservation_id)
+
     async def gen():
-        # Open one persistent session for the whole stream
-        session = aiohttp.ClientSession(timeout=request_timeout)
         sent_any = False
         try:
-            resp = await session.post(url, json=payload, headers=headers)
             try:
                 async for chunk in resp.content.iter_any():
                     if chunk:
@@ -3828,16 +3869,19 @@ async def _proxy_json(
                 path=path,
                 message=f"{type(e).__name__}: {e}",
             )
-            error = {
-                "error": {
-                    "message": (
-                        f"Worker stream failed after proxying {int(sent_any)} chunk(s): "
-                        f"{type(e).__name__}: {e}"
-                    ),
-                    "type": "worker_stream_error",
+            if (stream_media_type or "text/event-stream").startswith(
+                "text/event-stream"
+            ):
+                error = {
+                    "error": {
+                        "message": (
+                            f"Worker stream failed after proxying {int(sent_any)} chunk(s): "
+                            f"{type(e).__name__}: {e}"
+                        ),
+                        "type": "worker_stream_error",
+                    }
                 }
-            }
-            yield f"data: {json.dumps(error)}\n\n".encode("utf-8")
+                yield f"data: {json.dumps(error)}\n\n".encode("utf-8")
         finally:
             await session.close()
             registry.release_in_flight(worker.worker_id, reservation_id)

--- a/test_model_residency.py
+++ b/test_model_residency.py
@@ -213,6 +213,25 @@ class VoiceHandoffTests(unittest.IsolatedAsyncioTestCase):
         self.assertFalse(pipe._llm_temporarily_unavailable)
         self.assertFalse(pipe._voice_handoff_active())
 
+    async def test_voice_lease_can_be_released_from_a_streaming_task(self):
+        pipe = Pipes.__new__(Pipes)
+        pipe._voice_handoff_lock = asyncio.Lock()
+        pipe._voice_handoff_state_lock = threading.Lock()
+        pipe._voice_handoff_counts = {"tts": 0, "stt": 0}
+        pipe._inference_count_lock = threading.Lock()
+        pipe._llm_temporarily_unavailable = False
+        pipe._voice_should_unload_llm = mock.Mock(return_value=False)
+        guard = _VoiceSlotGuard(pipe, "tts", 1)
+
+        lease = await guard.acquire()
+
+        async def release_from_stream_task():
+            await guard.release(lease)
+
+        await asyncio.create_task(release_from_stream_task())
+        second = await asyncio.wait_for(guard.acquire(), timeout=0.2)
+        await guard.release(second)
+
     def test_voice_handoff_uses_lazy_llm_restore_by_default(self):
         pipe = Pipes.__new__(Pipes)
         pipe.available_models = ["model-a"]

--- a/test_router_streaming.py
+++ b/test_router_streaming.py
@@ -19,6 +19,153 @@ def _sse(payload: str) -> bytes:
 
 
 class RouterStreamingTests(unittest.IsolatedAsyncioTestCase):
+    async def test_binary_stream_propagates_upstream_setup_error(self):
+        worker = WorkerInfo(
+            worker_id="tts-worker",
+            label="tts-worker",
+            url="http://tts-worker",
+            capabilities=["tts"],
+            models=[],
+        )
+        registry = WorkerRegistry(ttl_seconds=60)
+        registry.register(worker)
+
+        class FakeResponse:
+            status = 503
+            headers = {"Content-Type": "application/json"}
+
+            async def read(self):
+                return b'{"detail":"TTS model unavailable"}'
+
+            def release(self):
+                return None
+
+        class FakeSession:
+            def __init__(self, **_kwargs):
+                self.closed = False
+
+            async def post(self, *_args, **_kwargs):
+                return FakeResponse()
+
+            async def close(self):
+                self.closed = True
+
+        with patch("router_app.get_registry", return_value=registry), patch(
+            "router_app.aiohttp.ClientSession", FakeSession
+        ):
+            response = await router_app._proxy_json(
+                worker,
+                "/v1/audio/speech/stream",
+                {"input": "Hello"},
+                stream=True,
+                capability="tts",
+                stream_media_type="application/octet-stream",
+            )
+
+        self.assertEqual(response.status_code, 503)
+        self.assertEqual(response.body, b'{"detail":"TTS model unavailable"}')
+        self.assertEqual(worker.router_in_flight, 0)
+
+    async def test_binary_stream_does_not_append_sse_error_payload(self):
+        worker = WorkerInfo(
+            worker_id="tts-worker",
+            label="tts-worker",
+            url="http://tts-worker",
+            capabilities=["tts"],
+            models=[],
+        )
+        registry = WorkerRegistry(ttl_seconds=60)
+        registry.register(worker)
+
+        class FakeContent:
+            async def iter_any(self):
+                yield b"\x01\x02audio"
+                raise RuntimeError("voice worker disconnected")
+
+        class FakeResponse:
+            status = 200
+            headers = {"Content-Type": "application/octet-stream"}
+            content = FakeContent()
+
+            def release(self):
+                return None
+
+        class FakeSession:
+            def __init__(self, **_kwargs):
+                pass
+
+            async def post(self, *_args, **_kwargs):
+                return FakeResponse()
+
+            async def close(self):
+                return None
+
+        with patch("router_app.get_registry", return_value=registry), patch(
+            "router_app.aiohttp.ClientSession", FakeSession
+        ):
+            response = await router_app._proxy_json(
+                worker,
+                "/v1/audio/speech/stream",
+                {"input": "Hello"},
+                stream=True,
+                capability="tts",
+                stream_media_type="application/octet-stream",
+            )
+            body = b"".join([chunk async for chunk in response.body_iterator])
+
+        self.assertEqual(body, b"\x01\x02audio")
+        self.assertNotIn(b"data:", body)
+        self.assertEqual(worker.router_in_flight, 0)
+
+    async def test_tunnel_binary_stream_propagates_upstream_setup_error(self):
+        worker = WorkerInfo(
+            worker_id="tts-worker",
+            label="tts-worker",
+            url="tunnel://tts-worker",
+            capabilities=["tts"],
+            models=[],
+        )
+        registry = WorkerRegistry(ttl_seconds=60)
+        registry.register(worker)
+
+        async def error_chunks():
+            yield b'{"detail":"TTS model unavailable"}'
+
+        connection = type(
+            "Connection",
+            (),
+            {
+                "closed": False,
+                "request": AsyncMock(
+                    return_value=(
+                        503,
+                        {"Content-Type": "application/json"},
+                        error_chunks(),
+                    )
+                ),
+            },
+        )()
+        hub = type("Hub", (), {"get": lambda self, _wid: connection})()
+
+        with patch("router_app.get_registry", return_value=registry), patch(
+            "router_app.get_tunnel_hub", return_value=hub
+        ):
+            response = await router_app._proxy_via_tunnel(
+                worker,
+                "POST",
+                "/v1/audio/speech/stream",
+                headers={"Content-Type": "application/json"},
+                body=b"{}",
+                stream=True,
+                timeout=30,
+                capability="tts",
+                stream_media_type="application/octet-stream",
+            )
+
+        self.assertEqual(response.status_code, 503)
+        self.assertEqual(response.body, b'{"detail":"TTS model unavailable"}')
+        self.assertEqual(worker.router_in_flight, 0)
+
     def test_prompt_affinity_wait_default_covers_worker_heartbeat_release_lag(self):
         with patch.dict(os.environ, {}, clear=False):
             os.environ.pop("ROUTER_PROMPT_AFFINITY_WAIT", None)


### PR DESCRIPTION
## Summary
- transfer explicit voice-slot leases safely between the request task and streaming iterator task
- acquire the GPU lease and load TTS before committing HTTP 200 so setup failures remain proper HTTP errors
- preserve upstream setup status and bodies through direct and tunnel router streaming paths
- avoid injecting SSE error text into interrupted binary audio streams
- document lazy LLM restoration behavior on shared voice workers

## Verification
- `python -m pytest -q test_model_residency.py test_router_streaming.py test_pipes_stream_tracking.py` (37 passed)
- Black formatting checks
- full CUDA compose rebuild/restart
- `/health` returned healthy
- routed and direct streaming TTS smoke tests returned valid 24 kHz mono PCM audio
- lifecycle logs confirmed LLM handoff, TTS load, generation, and cleanup without errors