### PR TITLE
Retry transient capability worker failures

### DIFF
--- a/router_app.py
+++ b/router_app.py
@@ -44,7 +44,7 @@ import os
 import re
 import time
 from datetime import datetime
-from typing import Any, AsyncIterator, Dict, List, Optional
+from typing import Any, AsyncIterator, Awaitable, Callable, Dict, List, Optional
 
 import aiohttp
 from fastapi import (
@@ -3346,8 +3346,8 @@ def _max_retries() -> int:
 
 
 def _is_transient_failure(status: int) -> bool:
-    """5xx and 408 are worth retrying on a different worker; 4xx are client errors."""
-    return status == 408 or 500 <= status <= 599
+    """Worker timeouts, saturation, and 5xx responses are safe to retry."""
+    return status in (408, 429) or 500 <= status <= 599
 
 
 def _float_env(name: str, default: float) -> float:
@@ -4443,6 +4443,7 @@ async def _proxy_multipart(
     timeout: Optional[float] = None,
     capability: Optional[str] = None,
     model: Optional[str] = None,
+    reservation_id: Optional[str] = None,
 ) -> Response:
     """Forward a multipart/form-data POST to a worker.
 
@@ -4496,6 +4497,7 @@ async def _proxy_multipart(
             timeout=timeout,
             capability=capability,
             model=model,
+            reservation_id=reservation_id,
         )
 
     # Direct (non-tunneled) multipart upload via aiohttp.
@@ -4512,9 +4514,10 @@ async def _proxy_multipart(
 
     url = f"{worker.url}{path}"
     registry = get_registry()
-    reservation_id = registry.increment_in_flight(
-        worker.worker_id, 1, capability=capability, model=model
-    )
+    if reservation_id is None:
+        reservation_id = registry.increment_in_flight(
+            worker.worker_id, 1, capability=capability, model=model
+        )
     try:
         async with aiohttp.ClientSession(timeout=request_timeout) as session:
             async with session.post(url, data=data, headers=headers) as resp:
@@ -4535,6 +4538,197 @@ async def _proxy_multipart(
         raise
     finally:
         registry.release_in_flight(worker.worker_id, reservation_id)
+
+
+def _eligible_capability_worker_ids(capability: str) -> set:
+    """Return selectable local/managed workers for retry exclusion rotation."""
+    try:
+        tunnel_hub = get_tunnel_hub()
+        return {
+            worker.worker_id
+            for worker in get_registry().list_workers(alive_only=True)
+            if capability in worker.capabilities
+            and not worker.is_circuit_open()
+            and (
+                not is_tunnel_url(worker.url)
+                or tunnel_hub.is_connected(worker_id_from_tunnel_url(worker.url))
+            )
+        }
+    except Exception:
+        return set()
+
+
+async def _capability_proxy_with_retry(
+    *,
+    capability: str,
+    path: str,
+    model: Optional[str],
+    request_attempt: Callable[[WorkerInfo, Optional[str]], Awaitable[Any]],
+) -> tuple[WorkerInfo, Any]:
+    """Queue and retry a non-LLM capability request across healthy workers.
+
+    Worker selection already waits for advertised capacity. This wrapper also
+    handles the race between selection and dispatch plus transient failures
+    returned after a worker has accepted the request.
+    """
+    registry = get_registry()
+    max_attempts = _stream_max_attempts(capability)
+    tried: set = set()
+    last_error: Optional[Exception] = None
+    last_status: Optional[int] = None
+    attempts = 0
+
+    while attempts < max_attempts:
+        eligible_ids = _eligible_capability_worker_ids(capability)
+        if tried and (not eligible_ids or eligible_ids.issubset(tried)):
+            tried.clear()
+            await asyncio.sleep(min(0.25 * max(1, attempts), 1.0))
+
+        worker = await _pick(capability, model, exclude=tried)
+        reservation_id = registry.try_reserve_in_flight(
+            worker.worker_id,
+            capability=capability,
+            model=model,
+        )
+        llm_dependencies = set(
+            worker.extra.get("llm_unload_dependent_capabilities", []) or []
+        )
+        requires_reservation = capability in ("text", "vision") or (
+            capability in llm_dependencies
+        )
+        if reservation_id is None and requires_reservation:
+            logging.info(
+                "[Router] worker %s lost a %s dispatch race; returning to queue",
+                worker.label,
+                capability,
+            )
+            await asyncio.sleep(0.05)
+            continue
+
+        attempts += 1
+        tried.add(worker.worker_id)
+        try:
+            response = await request_attempt(worker, reservation_id)
+        except Exception as error:
+            last_error = error
+            logging.warning(
+                "[Router] %s attempt %d/%d via %s raised %s: %s; retrying",
+                path,
+                attempts,
+                max_attempts,
+                worker.label,
+                type(error).__name__,
+                error,
+            )
+            continue
+
+        last_error = None
+        status = int(getattr(response, "status_code", 200) or 200)
+        if _is_transient_failure(status):
+            last_status = status
+            try:
+                body_snippet = bytes(getattr(response, "body", b"") or b"").decode(
+                    "utf-8", errors="replace"
+                )[:500]
+            except Exception:
+                body_snippet = ""
+            registry.record_error(
+                worker.worker_id,
+                kind="http_5xx" if status >= 500 else "http_retryable",
+                path=path,
+                message=body_snippet or f"HTTP {status}",
+                status=status,
+            )
+            if attempts < max_attempts:
+                logging.warning(
+                    "[Router] %s attempt %d/%d via %s returned %d; retrying",
+                    path,
+                    attempts,
+                    max_attempts,
+                    worker.label,
+                    status,
+                )
+                continue
+        else:
+            return worker, response
+
+    if last_error is not None:
+        raise HTTPException(
+            status_code=502,
+            detail=(
+                f"All {max_attempts} worker attempts failed for {path}: "
+                f"{type(last_error).__name__}: {last_error}"
+            ),
+        )
+    raise HTTPException(
+        status_code=502,
+        detail=(
+            f"All {max_attempts} worker attempts returned transient errors "
+            f"(last status {last_status}) for {path}"
+        ),
+    )
+
+
+async def _proxy_json_capability_with_retry(
+    *,
+    capability: str,
+    path: str,
+    payload: Dict[str, Any],
+    model: Optional[str] = None,
+    stream: bool = False,
+    timeout: Optional[float] = None,
+    stream_media_type: Optional[str] = None,
+    stream_headers: Optional[Dict[str, str]] = None,
+) -> tuple[WorkerInfo, Any]:
+    async def request_attempt(worker: WorkerInfo, reservation_id: Optional[str]):
+        return await _proxy_json(
+            worker,
+            path,
+            payload,
+            stream=stream,
+            timeout=timeout,
+            capability=capability,
+            model=model,
+            stream_media_type=stream_media_type,
+            stream_headers=stream_headers,
+            reservation_id=reservation_id,
+        )
+
+    return await _capability_proxy_with_retry(
+        capability=capability,
+        path=path,
+        model=model,
+        request_attempt=request_attempt,
+    )
+
+
+async def _proxy_multipart_capability_with_retry(
+    *,
+    capability: str,
+    path: str,
+    files: Dict[str, tuple],
+    fields: Dict[str, Any],
+    model: Optional[str] = None,
+    timeout: Optional[float] = None,
+) -> tuple[WorkerInfo, Response]:
+    async def request_attempt(worker: WorkerInfo, reservation_id: Optional[str]):
+        return await _proxy_multipart(
+            worker,
+            path,
+            files=files,
+            fields=fields,
+            timeout=timeout,
+            capability=capability,
+            model=model,
+            reservation_id=reservation_id,
+        )
+
+    return await _capability_proxy_with_retry(
+        capability=capability,
+        path=path,
+        model=model,
+        request_attempt=request_attempt,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -4760,14 +4954,11 @@ async def _llm_proxy_with_retry(
 
 @app.post("/v1/embeddings", tags=["Embeddings"])
 async def embeddings(payload: Dict[str, Any], _: str = Depends(verify_client)):
-    worker = await _pick("embedding", payload.get("model"))
     start = time.perf_counter()
-    resp = await _proxy_json(
-        worker,
-        "/v1/embeddings",
-        payload,
-        stream=False,
+    worker, resp = await _proxy_json_capability_with_retry(
         capability="embedding",
+        path="/v1/embeddings",
+        payload=payload,
         model=payload.get("model"),
     )
     total_ms = (time.perf_counter() - start) * 1000.0
@@ -4800,10 +4991,12 @@ async def audio_speech(
     request: Request,
     _: str = Depends(verify_client),
 ):
-    worker = await _pick("tts", payload.get("model"))
     start = time.perf_counter()
-    resp = await _proxy_json(
-        worker, "/v1/audio/speech", payload, stream=False, capability="tts"
+    worker, resp = await _proxy_json_capability_with_retry(
+        capability="tts",
+        path="/v1/audio/speech",
+        payload=payload,
+        model=payload.get("model"),
     )
     total_ms = (time.perf_counter() - start) * 1000.0
     if int(getattr(resp, "status_code", 200) or 200) < 400:
@@ -4819,14 +5012,13 @@ async def audio_speech(
 
 @app.post("/v1/audio/speech/stream", tags=["Audio"])
 async def audio_speech_stream(payload: Dict[str, Any], _: str = Depends(verify_client)):
-    worker = await _pick("tts", payload.get("model"))
     start = time.perf_counter()
-    resp = await _proxy_json(
-        worker,
-        "/v1/audio/speech/stream",
-        payload,
-        stream=True,
+    worker, resp = await _proxy_json_capability_with_retry(
         capability="tts",
+        path="/v1/audio/speech/stream",
+        payload=payload,
+        model=payload.get("model"),
+        stream=True,
         stream_media_type="application/octet-stream",
         stream_headers={
             "X-Audio-Format": "pcm",
@@ -4854,18 +5046,16 @@ async def audio_music(
     request: Request,
     _: str = Depends(verify_client),
 ):
-    worker = await _pick("music", payload.get("model"))
     start = time.perf_counter()
-    resp = await _proxy_json(
-        worker,
-        "/v1/audio/music",
-        payload,
-        stream=False,
+    worker, resp = await _proxy_json_capability_with_retry(
+        capability="music",
+        path="/v1/audio/music",
+        payload=payload,
+        model=payload.get("model"),
         timeout=max(
             float(getenv("REQUEST_TIMEOUT", "1800")),
             float(getenv("ACE_STEP_TIMEOUT", "1800")),
         ),
-        capability="music",
     )
     total_ms = (time.perf_counter() - start) * 1000.0
     if int(getattr(resp, "status_code", 200) or 200) < 400:
@@ -4915,13 +5105,12 @@ async def audio_transcriptions(
     ),
     _: str = Depends(verify_client),
 ):
-    worker = await _pick("stt", model)
     content = await file.read()
     granularities = timestamp_granularities_bracketed or timestamp_granularities
     start = time.perf_counter()
-    resp = await _proxy_multipart(
-        worker,
-        "/v1/audio/transcriptions",
+    worker, resp = await _proxy_multipart_capability_with_retry(
+        capability="stt",
+        path="/v1/audio/transcriptions",
         files={
             "file": (
                 file.filename or "audio.wav",
@@ -4939,7 +5128,6 @@ async def audio_transcriptions(
             "timestamp_granularities[]": granularities,
         },
         timeout=_stt_timeout(),
-        capability="stt",
         model=model,
     )
     total_ms = (time.perf_counter() - start) * 1000.0
@@ -4960,10 +5148,12 @@ async def images_generations(
     request: Request,
     _: str = Depends(verify_client),
 ):
-    worker = await _pick("image", payload.get("model"))
     start = time.perf_counter()
-    resp = await _proxy_json(
-        worker, "/v1/images/generations", payload, stream=False, capability="image"
+    worker, resp = await _proxy_json_capability_with_retry(
+        capability="image",
+        path="/v1/images/generations",
+        payload=payload,
+        model=payload.get("model"),
     )
     total_ms = (time.perf_counter() - start) * 1000.0
     if int(getattr(resp, "status_code", 200) or 200) < 400:
@@ -4983,10 +5173,12 @@ async def images_edits(request: Request, _: str = Depends(verify_client)):
     content_type = (request.headers.get("content-type") or "").lower()
     if "application/json" in content_type:
         payload = await request.json()
-        worker = await _pick("image", payload.get("model"))
         start = time.perf_counter()
-        resp = await _proxy_json(
-            worker, "/v1/images/edits", payload, stream=False, capability="image"
+        worker, resp = await _proxy_json_capability_with_retry(
+            capability="image",
+            path="/v1/images/edits",
+            payload=payload,
+            model=payload.get("model"),
         )
         total_ms = (time.perf_counter() - start) * 1000.0
         if int(getattr(resp, "status_code", 200) or 200) < 400:
@@ -5012,14 +5204,13 @@ async def images_edits(request: Request, _: str = Depends(verify_client)):
             )
         else:
             fields[key] = str(value)
-    worker = await _pick("image", fields.get("model"))
     start = time.perf_counter()
-    resp = await _proxy_multipart(
-        worker,
-        "/v1/images/edits",
+    worker, resp = await _proxy_multipart_capability_with_retry(
+        capability="image",
+        path="/v1/images/edits",
         files=files,
         fields=fields,
-        capability="image",
+        model=fields.get("model"),
     )
     total_ms = (time.perf_counter() - start) * 1000.0
     if int(getattr(resp, "status_code", 200) or 200) < 400:
@@ -5039,15 +5230,13 @@ async def videos_generations(
     request: Request,
     _: str = Depends(verify_client),
 ):
-    worker = await _pick("video", payload.get("model"))
     start = time.perf_counter()
-    resp = await _proxy_json(
-        worker,
-        "/v1/videos/generations",
-        payload,
-        stream=False,
-        timeout=float(getenv("REQUEST_TIMEOUT", "1800")),
+    worker, resp = await _proxy_json_capability_with_retry(
         capability="video",
+        path="/v1/videos/generations",
+        payload=payload,
+        model=payload.get("model"),
+        timeout=float(getenv("REQUEST_TIMEOUT", "1800")),
     )
     total_ms = (time.perf_counter() - start) * 1000.0
     if int(getattr(resp, "status_code", 200) or 200) < 400:
@@ -5068,27 +5257,24 @@ async def music_videos_generations(
     request: Request,
     _: str = Depends(verify_client),
 ):
-    worker = await _pick(
-        "music_video", payload.get("video_model") or payload.get("model")
-    )
+    model = payload.get("video_model") or payload.get("model")
     start = time.perf_counter()
-    resp = await _proxy_json(
-        worker,
-        "/v1/videos/music",
-        payload,
-        stream=False,
+    worker, resp = await _proxy_json_capability_with_retry(
+        capability="music_video",
+        path="/v1/videos/music",
+        payload=payload,
+        model=model,
         timeout=max(
             float(getenv("REQUEST_TIMEOUT", "1800")),
             float(getenv("ACE_STEP_TIMEOUT", "1800")),
         ),
-        capability="music_video",
     )
     total_ms = (time.perf_counter() - start) * 1000.0
     if int(getattr(resp, "status_code", 200) or 200) < 400:
         await _record_cap_success(
             worker,
             "music_video",
-            requested_model=payload.get("video_model") or payload.get("model"),
+            requested_model=model,
             total_ms=total_ms,
             outputs=_json_response_output_count(resp),
         )

--- a/test_router_capability_retry.py
+++ b/test_router_capability_retry.py
@@ -1,0 +1,199 @@
+import pathlib
+import sys
+import unittest
+from unittest.mock import AsyncMock, patch
+
+
+ROOT = pathlib.Path(__file__).resolve().parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from Router import WorkerInfo, WorkerRegistry
+import router_app
+
+
+def _worker(worker_id: str, capability: str = "embedding") -> WorkerInfo:
+    return WorkerInfo(
+        worker_id=worker_id,
+        label=worker_id,
+        url=f"http://{worker_id}.local",
+        capabilities=[capability],
+        models=[],
+        cap_slots={
+            capability: {
+                "capacity": 1,
+                "in_flight": 0,
+                "queued": 0,
+                "available": 1,
+            }
+        },
+    )
+
+
+class RouterCapabilityRetryTests(unittest.IsolatedAsyncioTestCase):
+    async def test_embedding_worker_500_fails_over(self):
+        registry = WorkerRegistry(ttl_seconds=60)
+        first = registry.register(_worker("first"))
+        second = registry.register(_worker("second"))
+        responses = [
+            router_app.Response(content=b'{"error":"busy"}', status_code=500),
+            router_app.Response(content=b'{"data":[]}', status_code=200),
+        ]
+        selected = []
+
+        async def pick(_capability, _model, exclude=None):
+            excluded = set(exclude or ())
+            worker = first if first.worker_id not in excluded else second
+            selected.append(worker.worker_id)
+            return worker
+
+        async def proxy(worker, _path, _payload, **kwargs):
+            registry.release_in_flight(worker.worker_id, kwargs["reservation_id"])
+            return responses.pop(0)
+
+        with (
+            patch("router_app.get_registry", return_value=registry),
+            patch("router_app._pick", side_effect=pick),
+            patch("router_app._proxy_json", side_effect=proxy),
+        ):
+            worker, response = await router_app._proxy_json_capability_with_retry(
+                capability="embedding",
+                path="/v1/embeddings",
+                payload={"input": "hello"},
+                model=None,
+            )
+
+        self.assertIs(worker, second)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(selected, ["first", "second"])
+        self.assertEqual(first.total_errors, 1)
+
+    async def test_single_worker_is_requeued_after_transient_failure(self):
+        registry = WorkerRegistry(ttl_seconds=60)
+        worker = registry.register(_worker("only"))
+        responses = [
+            router_app.Response(content=b'{"error":"saturated"}', status_code=429),
+            router_app.Response(content=b'{"data":[]}', status_code=200),
+        ]
+
+        async def proxy(worker_arg, _path, _payload, **kwargs):
+            registry.release_in_flight(worker_arg.worker_id, kwargs["reservation_id"])
+            return responses.pop(0)
+
+        with (
+            patch("router_app.get_registry", return_value=registry),
+            patch("router_app._pick", AsyncMock(return_value=worker)) as pick,
+            patch("router_app._proxy_json", side_effect=proxy),
+            patch("router_app.asyncio.sleep", AsyncMock()),
+        ):
+            selected, response = await router_app._proxy_json_capability_with_retry(
+                capability="embedding",
+                path="/v1/embeddings",
+                payload={"input": "hello"},
+                model=None,
+            )
+
+        self.assertIs(selected, worker)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(pick.await_count, 2)
+
+    async def test_client_error_is_returned_without_retry(self):
+        registry = WorkerRegistry(ttl_seconds=60)
+        worker = registry.register(_worker("only"))
+        response = router_app.Response(
+            content=b'{"detail":"invalid input"}', status_code=400
+        )
+
+        async def proxy(worker_arg, _path, _payload, **kwargs):
+            registry.release_in_flight(worker_arg.worker_id, kwargs["reservation_id"])
+            return response
+
+        with (
+            patch("router_app.get_registry", return_value=registry),
+            patch("router_app._pick", AsyncMock(return_value=worker)) as pick,
+            patch("router_app._proxy_json", side_effect=proxy),
+        ):
+            selected, result = await router_app._proxy_json_capability_with_retry(
+                capability="embedding",
+                path="/v1/embeddings",
+                payload={"input": ""},
+                model=None,
+            )
+
+        self.assertIs(selected, worker)
+        self.assertIs(result, response)
+        self.assertEqual(pick.await_count, 1)
+
+    async def test_multipart_transcription_reuses_upload_for_failover(self):
+        registry = WorkerRegistry(ttl_seconds=60)
+        first = registry.register(_worker("first", capability="stt"))
+        second = registry.register(_worker("second", capability="stt"))
+        responses = [
+            router_app.Response(content=b'{"error":"model busy"}', status_code=503),
+            router_app.Response(content=b'{"text":"hello"}', status_code=200),
+        ]
+        uploads = []
+
+        async def pick(_capability, _model, exclude=None):
+            return first if first.worker_id not in set(exclude or ()) else second
+
+        async def proxy(worker, _path, **kwargs):
+            uploads.append(kwargs["files"]["file"][1])
+            registry.release_in_flight(worker.worker_id, kwargs["reservation_id"])
+            return responses.pop(0)
+
+        with (
+            patch("router_app.get_registry", return_value=registry),
+            patch("router_app._pick", side_effect=pick),
+            patch("router_app._proxy_multipart", side_effect=proxy),
+        ):
+            worker, response = await router_app._proxy_multipart_capability_with_retry(
+                capability="stt",
+                path="/v1/audio/transcriptions",
+                files={"file": ("voice.wav", b"audio-data", "audio/wav")},
+                fields={"model": "whisper-1"},
+                model="whisper-1",
+            )
+
+        self.assertIs(worker, second)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(uploads, [b"audio-data", b"audio-data"])
+
+    async def test_dispatch_race_returns_to_queue_without_spending_retry(self):
+        registry = WorkerRegistry(ttl_seconds=60)
+        worker = registry.register(_worker("only"))
+        worker.extra["llm_unload_dependent_capabilities"] = ["embedding"]
+        response = router_app.Response(content=b'{"data":[]}', status_code=200)
+        original_reserve = registry.try_reserve_in_flight
+        reservations = [None]
+
+        def reserve(*args, **kwargs):
+            if reservations:
+                return reservations.pop()
+            return original_reserve(*args, **kwargs)
+
+        async def proxy(worker_arg, _path, _payload, **kwargs):
+            registry.release_in_flight(worker_arg.worker_id, kwargs["reservation_id"])
+            return response
+
+        with (
+            patch("router_app.get_registry", return_value=registry),
+            patch.object(registry, "try_reserve_in_flight", side_effect=reserve),
+            patch("router_app._pick", AsyncMock(return_value=worker)) as pick,
+            patch("router_app._proxy_json", side_effect=proxy) as proxy_mock,
+            patch("router_app.asyncio.sleep", AsyncMock()),
+        ):
+            _, result = await router_app._proxy_json_capability_with_retry(
+                capability="embedding",
+                path="/v1/embeddings",
+                payload={"input": "hello"},
+                model=None,
+            )
+
+        self.assertIs(result, response)
+        self.assertEqual(pick.await_count, 2)
+        self.assertEqual(proxy_mock.await_count, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- route embeddings and other non-LLM capabilities through queued worker failover instead of forwarding a selected worker's transient error directly
- retry connection failures, HTTP 408/429, and worker 5xx responses while preserving ordinary client 4xx responses
- replay multipart transcription/image-edit payloads safely across workers and honor shared-LLM dispatch reservations
- record transient capability failures in router diagnostics and circuit-breaker history

## Root cause
The router waited for advertised worker capacity during selection, but `/v1/embeddings` and the other capability endpoints used a one-shot proxy afterward. A selected worker's HTTP 500 bypassed the existing LLM retry/failover layer and was returned directly to WorkConductor. That path also did not record the HTTP failure in `/v1/router/errors`, which is why the historical XT School failure had no worker diagnostic attached.

## Verification
- `python -m unittest test_router_selection.py test_router_streaming.py test_router_dashboard.py test_router_chutes.py test_router_openrouter.py test_router_capability_retry.py` (128 passed)
- `python -m black --check router_app.py test_router_capability_retry.py`
- `python -m py_compile router_app.py Router.py`
- rebuilt/restarted `docker-compose-cuda.yml`; worker health returned 200
- restarted `docker-compose-router.yml`; router health returned 200
- reviewed worker/router logs; no runtime exceptions or routing errors
