### PR TITLE
Fix TTS/STT handoff GPU residency

### DIFF
--- a/Pipes.py
+++ b/Pipes.py
@@ -4164,6 +4164,8 @@ class Pipes:
         # Source model -> ordered list of internal replica IDs
         self.model_replicas = {}
         self.calibrated_gpu_layers = {}  # {model_name: {context: gpu_layers}}
+        # Last successfully loaded runtime shape, retained across voice handoffs.
+        self._known_llm_runtime_models = {}
 
         # Per-model configs parsed from comma-separated env vars
         # {model_name: {main_gpu, max_tokens, n_parallel, quant_type, tensor_split}}
@@ -4802,6 +4804,19 @@ class Pipes:
                 if getattr(self, "current_llm_name", None)
                 else None
             ),
+            "loaded_llm_runtime": [
+                {
+                    "model": self._resolve_source_model(model_id),
+                    **self._llm_runtime_shape(
+                        instance,
+                        (self.model_configs.get(model_id, {}) or {}).get(
+                            "max_tokens", self._optimal_context
+                        ),
+                    ),
+                }
+                for model_id, instance in getattr(self, "persistent_llms", {}).items()
+                if instance is not None
+            ],
             "vram_estimates_gb": dict(getattr(self, "llm_model_vram_estimates", {})),
             "summary": summaries,
             "recent_events": events,
@@ -4810,6 +4825,21 @@ class Pipes:
     def _resolve_source_model(self, model_name: str) -> str:
         """Resolve an internal model ID back to the source HF model name."""
         return self.model_sources.get(model_name, model_name)
+
+    @staticmethod
+    def _llm_runtime_shape(instance: Any, context: int) -> Dict[str, Any]:
+        """Capture the placement needed to reproduce a known-good LLM load."""
+        shape: Dict[str, Any] = {"context": int(context)}
+        gpu_layers = getattr(instance, "gpu_layers", None)
+        main_gpu = getattr(instance, "main_gpu", None)
+        tensor_split = getattr(instance, "tensor_split", None)
+        if gpu_layers is not None:
+            shape["gpu_layers"] = int(gpu_layers)
+        if main_gpu is not None:
+            shape["main_gpu"] = int(main_gpu)
+        if tensor_split:
+            shape["tensor_split"] = [float(value) for value in tensor_split]
+        return shape
 
     def _resolve_requested_model_id(self, requested_model: str) -> str:
         """Resolve a requested public model name to the primary internal model ID."""
@@ -4844,6 +4874,29 @@ class Pipes:
         quant_type: str = None,
     ) -> "LLM":
         """Load an LLM and record a consistent lifecycle benchmark event."""
+        runtime = getattr(self, "_known_llm_runtime_models", {}).get(model_name, {})
+        matching_runtime = int(runtime.get("context", 0) or 0) == int(max_tokens)
+        reused_runtime = False
+        if matching_runtime:
+            if gpu_layers is None and runtime.get("gpu_layers") is not None:
+                gpu_layers = runtime["gpu_layers"]
+                reused_runtime = True
+            if main_gpu is None and runtime.get("main_gpu") is not None:
+                main_gpu = runtime["main_gpu"]
+                reused_runtime = True
+            if tensor_split is None and runtime.get("tensor_split"):
+                tensor_split = runtime["tensor_split"]
+                reused_runtime = True
+        if reused_runtime:
+            logging.info(
+                "[LLM] Reusing known-good residency for %s: context=%s, "
+                "gpu_layers=%s, main_gpu=%s, tensor_split=%s",
+                model_name,
+                max_tokens,
+                gpu_layers,
+                main_gpu,
+                tensor_split or "none",
+            )
         started = time.perf_counter()
         try:
             instance = self._load_llm_resilient_impl(
@@ -4867,6 +4920,13 @@ class Pipes:
             self.llm_model_vram_estimates[model_name] = max(
                 float(actual_vram),
                 float(self.llm_model_vram_estimates.get(model_name, 0.0) or 0.0),
+            )
+        actual_layers = getattr(instance, "gpu_layers", None)
+        if actual_layers is not None:
+            if not hasattr(self, "_known_llm_runtime_models"):
+                self._known_llm_runtime_models = {}
+            self._known_llm_runtime_models[model_name] = self._llm_runtime_shape(
+                instance, max_tokens
             )
         self._record_model_lifecycle("load", "llm", model_name, elapsed)
         logging.info("[LLM] %s lifecycle load completed in %.2fs", model_name, elapsed)
@@ -6951,6 +7011,21 @@ class Pipes:
 
         refs: List[Tuple[str, Any]] = []
         with self._model_lock:
+            runtime_models = {}
+            for model_name, instance in self.persistent_llms.items():
+                if instance is None:
+                    continue
+                cfg = self.model_configs.get(model_name, {}) or {}
+                runtime_models[model_name] = self._llm_runtime_shape(
+                    instance, cfg.get("max_tokens", self._optimal_context)
+                )
+            if self.llm is not None and self.current_llm_name not in runtime_models:
+                runtime_models[self.current_llm_name or "LLM"] = (
+                    self._llm_runtime_shape(
+                        self.llm, self.current_context or self._optimal_context
+                    )
+                )
+            self._known_llm_runtime_models = dict(runtime_models)
             state = {
                 "loaded_models": [
                     model_name
@@ -6959,6 +7034,7 @@ class Pipes:
                 ],
                 "active_model": self.current_llm_name,
                 "active_context": self.current_context,
+                "runtime_models": runtime_models,
             }
             self._llm_temporarily_unavailable = True
             seen_ids = set()
@@ -7027,6 +7103,7 @@ class Pipes:
                 self._reload_persistent_models(
                     model_names=models_to_restore,
                     active_model=handoff_state.get("active_model"),
+                    runtime_models=handoff_state.get("runtime_models"),
                 )
         finally:
             self._llm_temporarily_unavailable = False
@@ -7564,6 +7641,7 @@ class Pipes:
         self,
         model_names: Optional[List[str]] = None,
         active_model: Optional[str] = None,
+        runtime_models: Optional[Dict[str, Dict[str, Any]]] = None,
     ):
         """Reload persistent models after using a large model.
 
@@ -7594,12 +7672,23 @@ class Pipes:
                     continue  # Already loaded
 
                 cfg = self.model_configs.get(model_name, {})
-                model_context = cfg.get("max_tokens", default_context)
-                logging.debug(f"[LLM] Reloading persistent model: {model_name}")
+                runtime = (runtime_models or {}).get(model_name, {})
+                model_context = runtime.get(
+                    "context", cfg.get("max_tokens", default_context)
+                )
+                gpu_layers = runtime.get("gpu_layers")
+                logging.info(
+                    "[LLM] Reloading persistent model %s at context=%s, "
+                    "gpu_layers=%s",
+                    model_name,
+                    model_context,
+                    gpu_layers if gpu_layers is not None else "auto",
+                )
                 try:
                     llm_instance = self._load_llm_resilient(
                         model_name=model_name,
                         max_tokens=model_context,
+                        gpu_layers=gpu_layers,
                         main_gpu=cfg.get("main_gpu"),
                         tensor_split=cfg.get("tensor_split"),
                         n_parallel=cfg.get("n_parallel"),
@@ -7816,10 +7905,21 @@ class Pipes:
         """Synchronous TTS destruction."""
         try:
             start_time = time.time()
+            close = getattr(tts_ref, "close", None)
+            if callable(close):
+                close()
             del tts_ref
             gc.collect()
             if torch.cuda.is_available():
+                try:
+                    torch.cuda.synchronize()
+                except Exception:
+                    pass
                 torch.cuda.empty_cache()
+                try:
+                    torch.cuda.ipc_collect()
+                except Exception:
+                    pass
             cleanup_time = time.time() - start_time
             logging.debug(f"[TTS] TTS model unloaded in {cleanup_time:.2f}s")
         except Exception as e:

--- a/README.md
+++ b/README.md
@@ -729,7 +729,12 @@ to keep voice models resident.
 `VOICE_WAIT_FOR_LLM_IDLE_TIMEOUT=60` controls the local race-safety timeout, and
 `VOICE_RELOAD_LLM_AFTER_GENERATION=false` controls eager restoration. It defaults
 to lazy restoration so native voice resources can fully unwind before the next
-text request reloads its LLM. Service-specific
+text request reloads its LLM. Voice teardown explicitly closes the native model
+even while the request still owns its wrapper. An eager or subsequent restore
+first retries the exact context and GPU-layer residency used before the handoff,
+then uses the normal resilient fallback only if that known-good allocation no
+longer fits. Current context and GPU layers are visible in
+`model_lifecycle.loaded_llm_runtime` from `GET /v1/resources`. Service-specific
 `TTS_...` and `STT_...` forms of these variables override the shared values. In
 voice server mode, ezlocalai instead warm-loads the configured number of resident
 instances and reports that parallel capacity to the router.

--- a/ezlocalai/CTTS.py
+++ b/ezlocalai/CTTS.py
@@ -700,6 +700,23 @@ class CTTS:
             except Exception as e:
                 logging.debug("[QTTS] CUDA cache cleanup skipped: %s", e)
 
+    def close(self):
+        """Release the native TTS model even if callers still hold this wrapper."""
+        model = getattr(self, "model", None)
+        self.model = None
+        del model
+        gc.collect()
+        if torch.cuda.is_available():
+            try:
+                torch.cuda.synchronize()
+            except Exception:
+                pass
+            torch.cuda.empty_cache()
+            try:
+                torch.cuda.ipc_collect()
+            except Exception:
+                pass
+
     def _resolve_language(self, language: Optional[str], text: str) -> str:
         requested = LANGUAGE_ALIASES.get(str(language or "").strip().lower())
         if requested is None:

--- a/test_ctts_chunking.py
+++ b/test_ctts_chunking.py
@@ -12,10 +12,35 @@ qwen_tts_stub = types.ModuleType("qwen_tts")
 qwen_tts_stub.Qwen3TTSModel = object
 sys.modules.setdefault("qwen_tts", qwen_tts_stub)
 
-from ezlocalai.CTTS import clean_text_for_tts, split_text_into_stream_chunks
+from ezlocalai.CTTS import CTTS, clean_text_for_tts, split_text_into_stream_chunks
 
 
 class CTTSChunkingTests(unittest.TestCase):
+    def test_close_releases_model_held_by_wrapper(self):
+        tts = CTTS.__new__(CTTS)
+        tts.model = object()
+        tts.device = "cuda:0"
+
+        from unittest import mock
+
+        with mock.patch("ezlocalai.CTTS.gc.collect") as collect, mock.patch(
+            "ezlocalai.CTTS.torch.cuda.is_available", return_value=True
+        ), mock.patch(
+            "ezlocalai.CTTS.torch.cuda.synchronize"
+        ) as synchronize, mock.patch(
+            "ezlocalai.CTTS.torch.cuda.empty_cache"
+        ) as empty_cache, mock.patch(
+            "ezlocalai.CTTS.torch.cuda.ipc_collect"
+        ) as ipc_collect:
+            tts.close()
+            tts.close()
+
+        self.assertIsNone(tts.model)
+        self.assertEqual(collect.call_count, 2)
+        self.assertEqual(synchronize.call_count, 2)
+        self.assertEqual(empty_cache.call_count, 2)
+        self.assertEqual(ipc_collect.call_count, 2)
+
     def test_stream_chunks_preserve_multilingual_sentences(self):
         text = clean_text_for_tts(
             "Hello. Привет, как дела? Повтори слово спасибо. Now say it slowly."

--- a/test_model_residency.py
+++ b/test_model_residency.py
@@ -186,6 +186,18 @@ class LlmDependencySlotTests(unittest.TestCase):
 
 
 class VoiceHandoffTests(unittest.IsolatedAsyncioTestCase):
+    async def test_voice_handoff_waits_for_active_llm_inference(self):
+        pipe = Pipes.__new__(Pipes)
+        pipe._is_inference_in_progress = mock.Mock(side_effect=[True, True, False])
+
+        with mock.patch.dict(
+            os.environ, {"VOICE_WAIT_FOR_LLM_IDLE_TIMEOUT": "1"}
+        ), mock.patch("Pipes.asyncio.sleep", new=mock.AsyncMock()) as sleep:
+            await pipe._wait_for_llm_idle_for_voice("tts")
+
+        self.assertEqual(pipe._is_inference_in_progress.call_count, 3)
+        self.assertEqual(sleep.await_count, 2)
+
     async def test_voice_slot_unloads_voice_before_restoring_llm(self):
         pipe = Pipes.__new__(Pipes)
         pipe._voice_handoff_lock = asyncio.Lock()
@@ -260,6 +272,112 @@ class VoiceHandoffTests(unittest.IsolatedAsyncioTestCase):
             pipe._destroy_stt_sync(stt)
 
         stt.close.assert_called_once_with()
+
+    def test_tts_destroy_closes_native_model_before_cache_cleanup(self):
+        pipe = Pipes.__new__(Pipes)
+        tts = mock.Mock()
+
+        with mock.patch("Pipes.gc.collect"), mock.patch(
+            "Pipes.torch.cuda.is_available", return_value=False
+        ):
+            pipe._destroy_tts_sync(tts)
+
+        tts.close.assert_called_once_with()
+
+    def test_voice_handoff_preserves_runtime_gpu_residency(self):
+        pipe = Pipes.__new__(Pipes)
+        resident = types.SimpleNamespace(gpu_layers=57)
+        pipe._model_lock = threading.Lock()
+        pipe.persistent_llms = {"model-a": resident}
+        pipe.model_configs = {"model-a": {"max_tokens": 200000}}
+        pipe._optimal_context = 200000
+        pipe.current_llm_name = "model-a"
+        pipe.current_context = 200000
+        pipe.llm = resident
+        pipe.primary_llm = resident
+        pipe.vision_llm = None
+        pipe._using_large_model = False
+        pipe.resource_manager = mock.Mock()
+        pipe._destroy_llm_refs_sync = mock.Mock()
+
+        state = pipe._unload_llms_for_service("tts", True)
+
+        self.assertEqual(
+            state["runtime_models"]["model-a"],
+            {"context": 200000, "gpu_layers": 57},
+        )
+
+    def test_llm_restore_reuses_pre_handoff_gpu_layers(self):
+        pipe = Pipes.__new__(Pipes)
+        pipe._model_lock = threading.Lock()
+        pipe._optimal_context = 200000
+        pipe.available_models = ["model-a"]
+        pipe.persistent_llms = {"model-a": None}
+        pipe.model_configs = {"model-a": {"max_tokens": 200000}}
+        pipe.llm_model_residency = "resident"
+        pipe.primary_llm_name = "model-a"
+        pipe.vision_llm_name = "vision"
+        pipe.primary_llm = None
+        pipe.vision_llm = None
+        pipe.llm = None
+        pipe.current_llm_name = None
+        pipe.current_context = None
+        pipe.resource_manager = mock.Mock()
+        restored = types.SimpleNamespace(is_vision=False, gpu_layers=57)
+        pipe._load_llm_resilient = mock.Mock(return_value=restored)
+
+        pipe._reload_persistent_models(
+            model_names=["model-a"],
+            active_model="model-a",
+            runtime_models={"model-a": {"context": 200000, "gpu_layers": 57}},
+        )
+
+        pipe._load_llm_resilient.assert_called_once_with(
+            model_name="model-a",
+            max_tokens=200000,
+            gpu_layers=57,
+            main_gpu=None,
+            tensor_split=None,
+            n_parallel=None,
+            quant_type=None,
+        )
+        self.assertIs(pipe.llm, restored)
+
+    def test_lazy_llm_restore_reuses_pre_handoff_gpu_layers(self):
+        pipe = Pipes.__new__(Pipes)
+        pipe._known_llm_runtime_models = {
+            "model-a": {
+                "context": 200000,
+                "gpu_layers": 57,
+                "main_gpu": 1,
+                "tensor_split": [0.4, 0.6],
+            }
+        }
+        pipe.llm_model_vram_estimates = {}
+        pipe._record_model_lifecycle = mock.Mock()
+        restored = types.SimpleNamespace(
+            gpu_layers=57,
+            main_gpu=1,
+            tensor_split=[0.4, 0.6],
+            vram_load_delta_gb=18.0,
+        )
+        pipe._load_llm_resilient_impl = mock.Mock(return_value=restored)
+
+        result = pipe._load_llm_resilient(
+            model_name="model-a",
+            max_tokens=200000,
+        )
+
+        self.assertIs(result, restored)
+        pipe._load_llm_resilient_impl.assert_called_once_with(
+            model_name="model-a",
+            max_tokens=200000,
+            gpu_layers=57,
+            main_gpu=1,
+            tensor_split=[0.4, 0.6],
+            n_parallel=None,
+            quant_type=None,
+        )
 
 
 class LlmSwapQueueTests(unittest.IsolatedAsyncioTestCase):


### PR DESCRIPTION
## Summary
- explicitly close Qwen-TTS native model state before restoring text inference capacity
- preserve known-good LLM context, GPU layers, GPU placement, and tensor split across eager and lazy voice handoffs
- expose live LLM placement under `model_lifecycle.loaded_llm_runtime` for diagnostics
- retain the existing active-inference drain and lazy voice restore defaults

## Root cause
The TTS pool removed its reference during cleanup, but endpoint handlers could still hold the `CTTS` wrapper while the shared voice lease released. Since `CTTS` had no explicit close method, its native model could remain allocated while the LLM reloaded, forcing the resilient loader to settle on fewer GPU layers.

## Verification
- focused host tests: 40 passed
- broad host discovery: 228 passed, 1 skipped; the only host error was `test_embedding` missing the container-only `xllamacpp` package
- native container tests including embedding: 42 passed
- rebuilt and restarted `docker-compose-cuda.yml`
- live `/v1/audio/speech` produced a valid 24 kHz WAV
- immediate chat completion succeeded after handoff
- runtime logs confirmed:
  - resident LLM unloaded before TTS
  - TTS allocation fully released
  - next text request reused `context=220000`, `gpu_layers=-1`, `main_gpu=0`
  - restored native LLM allocation remained 19.6 GB with all layers on GPU
- no startup, handoff, OOM, or model-load errors in container logs
