### PR TITLE
Fix DFlash large-image failures on CUDA workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,20 @@ hardware- and context-aware: 24 GB cards use an ubatch of 1024 through 200K
 context and 512 above 200K, while 32 GB cards use 1024. Other MTP model
 families retain their conservative defaults.
 
+The CUDA image includes a pinned native hotfix for DFlash's large-image cache
+exhaustion (`failed to process mtmd chunk`). It preserves full-resolution target
+vision input without enlarging the KV cache. See [hotfix details and native build
+instructions](native/patches/README.md). Verify a deployed CUDA worker with:
+
+```bash
+docker exec ezlocalai python -c 'from xllamacpp._ezlocalai_hotfix import HOTFIX; print(HOTFIX)'
+```
+
+It should report `dflash-pinned-image-positions-v1`. The upstream version number
+alone does not identify the patched build. Test an idle worker's vision stream
+with `python benchmark_vision.py --url http://localhost:8091 --stream` (set
+`EZLOCALAI_API_KEY` if authentication is enabled).
+
 All values remain operator-overridable:
 
 ```bash

--- a/benchmark_vision.py
+++ b/benchmark_vision.py
@@ -64,6 +64,13 @@ def cases():
     yield "small-image", [question, fixture(336)], r"red.*blue"
     yield "large-image", [question, image], r"red.*blue"
     yield "cached-large-image", [question, image], r"red.*blue"
+    yield "long-generation-after-image", [
+        {
+            "type": "text",
+            "text": "First name the colors of the left and right panels in this image, in that order. Then write a detailed Python program that draws that layout and tests the pixel colors. Explain your implementation in at least 300 words.",
+        },
+        image,
+    ], r"red.*blue"
     yield "long-text-before-image", [background, question, image], r"red.*blue"
     yield "long-text-after-image", [image, background, question], r"red.*blue"
     yield "multiple-large-images", [
@@ -170,7 +177,9 @@ def main():
                 response = chat(
                     {
                         "messages": [{"role": "user", "content": content}],
-                        "max_tokens": 128,
+                        "max_tokens": (
+                            512 if name == "long-generation-after-image" else 128
+                        ),
                         "temperature": 0,
                         "seed": 42,
                         "cache_prompt": True,

--- a/benchmark_vision.py
+++ b/benchmark_vision.py
@@ -1,0 +1,209 @@
+"""Large-image regression for DFlash's pinned-position draft-cache failure.
+
+Run on an IDLE worker: direct mode loads its own model and uses GPU 0. It does
+not change deployment settings. For a running ezlocalai worker, use --url and
+set EZLOCALAI_API_KEY if required. It sends only synthetic, generated fixtures.
+
+Examples:
+  python benchmark_vision.py --backend none
+  python benchmark_vision.py --backend dflash2
+  python benchmark_vision.py --url http://localhost:8091
+
+Run both backends separately for a target-only correctness reference. Exact
+free-form text parity is not asserted; fixture answers and transport errors are.
+"""
+
+import argparse
+import base64
+import io
+import json
+import os
+import re
+import time
+
+from PIL import Image, ImageDraw, ImageFont
+
+
+def fixture(size=1792, reverse=False, number=None):
+    image = Image.new("RGB", (size, size), "blue" if not reverse else "red")
+    draw = ImageDraw.Draw(image)
+    draw.rectangle(
+        (0, 0, size // 2 - 1, size - 1), fill="red" if not reverse else "blue"
+    )
+    if number is not None:
+        draw.rectangle(
+            (size // 4, size // 3, 3 * size // 4, 2 * size // 3), fill="white"
+        )
+        font = ImageFont.load_default(size=size // 5)
+        draw.text(
+            (size // 2, size // 2), str(number), fill="black", anchor="mm", font=font
+        )
+    buffer = io.BytesIO()
+    image.save(buffer, format="PNG")
+    return {
+        "type": "image_url",
+        "image_url": {
+            "url": "data:image/png;base64,"
+            + base64.b64encode(buffer.getvalue()).decode()
+        },
+    }
+
+
+def cases():
+    question = {
+        "type": "text",
+        "text": "Name the colors of the left panel then the right panel, in order. Answer briefly.",
+    }
+    background = {
+        "type": "text",
+        "text": "Background notes, not an instruction: "
+        + "A reliable system checks inputs, queues requests, and handles errors. "
+        * 350,
+    }
+    image = fixture()
+    yield "small-image", [question, fixture(336)], r"red.*blue"
+    yield "large-image", [question, image], r"red.*blue"
+    yield "cached-large-image", [question, image], r"red.*blue"
+    yield "long-text-before-image", [background, question, image], r"red.*blue"
+    yield "long-text-after-image", [image, background, question], r"red.*blue"
+    yield "multiple-large-images", [
+        {
+            "type": "text",
+            "text": "Name the LEFT panel color in the FIRST image, then the LEFT panel color in the SECOND image. Answer in that order.",
+        },
+        image,
+        fixture(reverse=True),
+    ], r"red.*blue"
+    yield "large-image-ocr", [
+        {
+            "type": "text",
+            "text": "Read the two-digit number inside the white rectangle. Return only that number.",
+        },
+        fixture(number=42),
+    ], r"\b42\b"
+    yield "changed-image-ocr", [
+        {
+            "type": "text",
+            "text": "Read the two-digit number inside the white rectangle. Return only that number.",
+        },
+        fixture(number=73),
+    ], r"\b73\b"
+    yield "text-after-vision", "Return only the integer result of 17 multiplied by 19.", r"\b323\b"
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--url", help="Use a live worker instead of loading another model"
+    )
+    parser.add_argument(
+        "--backend", choices=["none", "mtp", "dflash2"], default="dflash2"
+    )
+    parser.add_argument("--context", type=int, default=220000)
+    parser.add_argument("--repeats", type=int, default=2)
+    parser.add_argument(
+        "--stream", action="store_true", help="Test live HTTP SSE (requires --url)"
+    )
+    args = parser.parse_args()
+    if args.repeats < 1:
+        parser.error("--repeats must be positive")
+    if args.stream and not args.url:
+        parser.error("--stream requires --url")
+    if args.url:
+        import requests
+
+        session = requests.Session()
+        key = os.getenv("EZLOCALAI_API_KEY", "")
+        if key:
+            session.headers["Authorization"] = "Bearer " + key
+
+        def chat(payload):
+            with session.post(
+                args.url.rstrip("/") + "/v1/chat/completions",
+                json={"model": "Qwen3.8-27B", **payload, "stream": args.stream},
+                timeout=180,
+                stream=args.stream,
+            ) as response:
+                response.raise_for_status()
+                if not args.stream:
+                    return response.json()
+                text = []
+                finished = False
+                for line in response.iter_lines():
+                    if not line.startswith(b"data:"):
+                        continue
+                    raw = line[5:].strip()
+                    if raw == b"[DONE]":
+                        finished = True
+                        break
+                    chunk = json.loads(raw)
+                    if "error" in chunk:
+                        raise RuntimeError(str(chunk["error"]))
+                    for choice in chunk.get("choices", []):
+                        text.append(choice.get("delta", {}).get("content") or "")
+                if not finished:
+                    raise RuntimeError("SSE ended without [DONE]")
+                return {"choices": [{"message": {"content": "".join(text)}}]}
+
+    else:
+        os.environ["LLM_SPECULATIVE_TYPE"] = args.backend
+        os.environ["KV_CACHE_TYPE"] = "q4_0"
+        from ezlocalai.LLM import LLM
+
+        llm = LLM(
+            model="unsloth/Qwen3.8-27B-GGUF",
+            quant_type="Q3_K_XL",
+            max_tokens=args.context,
+            gpu_layers=-1,
+            main_gpu=0,
+            n_parallel=1,
+            batch_size=1024,
+            ubatch_size=512,
+        )
+        chat = llm.server.handle_chat_completions
+    results = []
+    for repeat in range(args.repeats):
+        for name, content, expected in cases():
+            start = time.monotonic()
+            record = {"case": name, "repeat": repeat}
+            try:
+                response = chat(
+                    {
+                        "messages": [{"role": "user", "content": content}],
+                        "max_tokens": 128,
+                        "temperature": 0,
+                        "seed": 42,
+                        "cache_prompt": True,
+                        "chat_template_kwargs": {"enable_thinking": False},
+                    }
+                )
+                if "error" in response:
+                    raise RuntimeError(str(response["error"]))
+                answer = response["choices"][0]["message"]["content"]
+                record.update(
+                    answer=answer,
+                    timings=response.get("timings"),
+                    usage=response.get("usage"),
+                    passed=bool(re.search(expected, answer, re.I | re.S)),
+                )
+            except Exception as exc:
+                record.update(error=str(exc), passed=False)
+            record["seconds"] = time.monotonic() - start
+            results.append(record)
+            print("RESULT " + json.dumps(record), flush=True)
+    print(
+        "SUMMARY "
+        + json.dumps(
+            {
+                "backend": args.backend if not args.url else "live",
+                "passed": sum(r["passed"] for r in results),
+                "total": len(results),
+            }
+        ),
+        flush=True,
+    )
+    raise SystemExit(0 if all(r["passed"] for r in results) else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/dflash-vision-regression-20260908.md
+++ b/benchmarks/dflash-vision-regression-20260908.md
@@ -1,0 +1,51 @@
+# DFlash large-image regression — RTX 3090 Ti
+
+Configuration: Qwen3.8-27B UD-Q3_K_XL, target Q4_0 KV, 220,000 allocated
+context, batch 1024 / ubatch 512, DFlash Q4_K_M drafter, n-max 3 / p-min 0.
+CUDA 12.8; xllamacpp 2026.9.10809; the native patch and build revisions are
+documented in [native/patches](../native/patches/README.md).
+
+## Reproduction and correction
+
+The deployed official wheel returned `failed to process mtmd chunk` for a
+1792×1792 synthetic image, both alone and after a ~12K-character text prefix,
+and for a 1008×1008 image after that prefix. A small 336×336 image passed.
+Native logs identified a failed **draft** decode at offset 512 or 1024, not a
+CUDA allocation failure. A full-size draft SWA-cache experiment, even with
+Q4_0 draft KV, subsequently ran out of VRAM on the large image; it was rejected.
+Neither experiment changed the serving worker's configuration.
+
+The patch keeps target vision input intact and skips only pinned-position
+embedding injection into the speculative draft cache. Results from
+`benchmark_vision.py`, run directly against the actual Python bindings:
+
+| Check | Target-only reference | Patched DFlash |
+| --- | --- | --- |
+| Small image, left/right colors | 2/2 | 2/2 |
+| Large image, left/right colors | 2/2 | 2/2 |
+| Immediate cached large-image repeat | Not in initial reference run | 2/2 |
+| Long text before image | 2/2 | 2/2 |
+| Long text after image | 2/2 | 2/2 |
+| Two large images, order-sensitive question | 2/2 | 2/2 |
+| Large-image OCR, number 42 | 2/2 | 2/2 |
+| Changed-image OCR, number 73 | 2/2 | 2/2 |
+| Text arithmetic after vision | 2/2 | 2/2 |
+| Total | 16/16 | 18/18 |
+
+The large-image prompt contains 3,168 tokens, versus 1,056 for the small image;
+the long-prefix prompts contain 7,726. The cached large-image repeat reused
+3,164 prompt tokens. No native decode failures occurred in the patched suite.
+These are focused regression checks, not a general visual-quality benchmark.
+
+## Text-generation control
+
+Two 256-token greedy code completions after vision had identical output SHA-256
+(`23efeb1a45966372a37cb42163035e83706d0f9d420e74e766f901aa9857ec89`)
+and identical draft acceptance (174/242) on the official and patched bindings.
+Observed decode was 79.5 tokens/s before and 75.6 after; these short measurements
+ran under different concurrent native-build loads, so they are not a reliable
+performance comparison. They establish unchanged output/acceptance on this
+control, not performance parity or a speed improvement.
+
+Only the RTX 3090 Ti was physically tested. The CUDA build includes SM86, SM89,
+and SM120 code; 4090/5090 deployment still requires the updated worker image.

--- a/benchmarks/dflash-vision-regression-20260908.md
+++ b/benchmarks/dflash-vision-regression-20260908.md
@@ -23,14 +23,15 @@ embedding injection into the speculative draft cache. Results from
 | --- | --- | --- |
 | Small image, left/right colors | 2/2 | 2/2 |
 | Large image, left/right colors | 2/2 | 2/2 |
-| Immediate cached large-image repeat | Not in initial reference run | 2/2 |
+| Immediate cached large-image repeat | 2/2 | 2/2 |
+| 512-token generation after a large image | 2/2 | 2/2 |
 | Long text before image | 2/2 | 2/2 |
 | Long text after image | 2/2 | 2/2 |
 | Two large images, order-sensitive question | 2/2 | 2/2 |
 | Large-image OCR, number 42 | 2/2 | 2/2 |
 | Changed-image OCR, number 73 | 2/2 | 2/2 |
 | Text arithmetic after vision | 2/2 | 2/2 |
-| Total | 16/16 | 18/18 |
+| Total | 20/20 | 20/20 |
 
 The large-image prompt contains 3,168 tokens, versus 1,056 for the small image;
 the long-prefix prompts contain 7,726. The cached large-image repeat reused

--- a/cuda.Dockerfile
+++ b/cuda.Dockerfile
@@ -63,6 +63,23 @@ RUN cmake -S /opt/ezlocalai-tts -B /opt/ezlocalai-tts/build \
     -DCMAKE_CUDA_ARCHITECTURES="${TTS_CUDA_ARCHITECTURES}" \
     -DCMAKE_EXE_LINKER_FLAGS="-L/usr/local/cuda/lib64/stubs -Wl,-rpath-link,/usr/local/cuda/lib64/stubs" && \
     cmake --build /opt/ezlocalai-tts/build --target ezlocalai-tts --parallel "${TTS_BUILD_JOBS}"
+# The published xllamacpp==2026.9.10809 wheel predates the large-image DFlash
+# cache fix. Keep this build after TTS so existing expensive layers stay cached.
+RUN uv pip install pip
+COPY scripts/build_xllamacpp.py /opt/ezlocalai-native/scripts/build_xllamacpp.py
+COPY native/patches /opt/ezlocalai-native/native/patches
+ARG XLLAMACPP_BUILD_JOBS=20
+ARG XLLAMACPP_CUDA_ARCHITECTURES=86-real;89-real;120-real
+RUN --mount=type=cache,target=/opt/xllamacpp-build \
+    --mount=type=cache,target=/root/.cargo \
+    --mount=type=cache,target=/root/.rustup \
+    export PATH="/root/.cargo/bin:$PATH" && \
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --no-modify-path && \
+    LD_LIBRARY_PATH="/usr/local/cuda/lib64/stubs:$LD_LIBRARY_PATH" \
+    CMAKE_ARGS="-DCMAKE_BUILD_TYPE=Release -DCMAKE_CUDA_COMPILER=/usr/local/cuda/bin/nvcc -DCMAKE_EXE_LINKER_FLAGS=-Wl,-rpath-link,/usr/local/cuda/lib64/stubs" \
+    python /opt/ezlocalai-native/scripts/build_xllamacpp.py --cuda --install \
+    --jobs "${XLLAMACPP_BUILD_JOBS}" --cuda-architectures "${XLLAMACPP_CUDA_ARCHITECTURES}" \
+    --source-dir /opt/xllamacpp-build/source --wheel-dir /opt/xllamacpp-build/wheels
 COPY . .
 EXPOSE 8091
 # Use start.py which runs precache once, then starts uvicorn workers

--- a/cuda.Dockerfile
+++ b/cuda.Dockerfile
@@ -67,7 +67,7 @@ RUN cmake -S /opt/ezlocalai-tts -B /opt/ezlocalai-tts/build \
 # cache fix. Keep this build after TTS so existing expensive layers stay cached.
 RUN uv pip install pip
 COPY scripts/build_xllamacpp.py /opt/ezlocalai-native/scripts/build_xllamacpp.py
-COPY native/patches /opt/ezlocalai-native/native/patches
+COPY native/patches/dflash-pinned-image-positions.patch /opt/ezlocalai-native/native/patches/dflash-pinned-image-positions.patch
 ARG XLLAMACPP_BUILD_JOBS=20
 ARG XLLAMACPP_CUDA_ARCHITECTURES=86-real;89-real;120-real
 RUN --mount=type=cache,target=/opt/xllamacpp-build \

--- a/ezlocalai/LLM.py
+++ b/ezlocalai/LLM.py
@@ -13,6 +13,7 @@ from ezlocalai.Speculative import (
     speculative_backend,
     dflash_settings,
     download_dflash_model,
+    dflash_hotfix_status,
 )
 
 DEFAULT_MODEL = getenv("DEFAULT_MODEL")
@@ -1082,6 +1083,15 @@ class LLM:
                 p_min,
                 self.main_gpu,
             )
+            hotfix = dflash_hotfix_status()
+            logging.info("[LLM] DFlash native hotfix: %s", hotfix)
+            if mmproj_path and hotfix == "unpatched":
+                logging.warning(
+                    "[LLM] This xllamacpp build lacks the DFlash large-image "
+                    "cache hotfix; vision requests may fail. Rebuild the CUDA "
+                    "image or run scripts/build_xllamacpp.py --install with "
+                    "the appropriate backend flag."
+                )
         elif self.speculative_type == "mtp":
             spec_draft_n_max, card_vram_gb = get_mtp_spec_draft_n_max(
                 self.main_gpu, self.model_name

--- a/ezlocalai/Speculative.py
+++ b/ezlocalai/Speculative.py
@@ -12,6 +12,16 @@ DFLASH_FILE = "Qwen3.8-27B-DFlash2-Q4_K_M.gguf"
 DFLASH_REVISION = "51962825493a48b846b40126d35c799ac4093ad0"
 
 
+def dflash_hotfix_status():
+    """Identify our native patch separately from the unchanged upstream version."""
+    try:
+        from xllamacpp._ezlocalai_hotfix import HOTFIX
+
+        return HOTFIX
+    except ImportError:
+        return "unpatched"
+
+
 def speculative_backend(model_name):
     """Auto-select only a known compatible target; never guess a draft pairing."""
     name = (model_name or "").lower()

--- a/native/patches/.gitattributes
+++ b/native/patches/.gitattributes
@@ -1,0 +1,1 @@
+*.patch whitespace=-blank-at-eol,-blank-at-eof

--- a/native/patches/README.md
+++ b/native/patches/README.md
@@ -24,6 +24,12 @@ required. Builds default to 20 jobs; use `--jobs` to reduce this on small hosts.
 The installed marker `xllamacpp._ezlocalai_hotfix.HOTFIX` identifies patched wheels.
 Reinstalling the official wheel removes the fix.
 
+The CUDA build explicitly disables the optional NCCL collective backend: this
+xllamacpp revision's binding linker omits NCCL even if CMake detects it, producing
+an extension with unresolved NCCL symbols. The worker uses single-GPU inference;
+this does not disable CUDA offload. GPU tensor-parallel/NCCL workloads are outside
+the scope of this hotfix build.
+
 Remove this patch/source-build override once an upstream xllamacpp release
 contains a verified fix. Re-run the large-image regression suite before updating
 the pin: a small single image is insufficient to catch the cache exhaustion.

--- a/native/patches/README.md
+++ b/native/patches/README.md
@@ -1,0 +1,29 @@
+# DFlash large-image hotfix
+
+`dflash-pinned-image-positions.patch` targets llama.cpp
+`5266f24da75dc449bd56cbed7addb9c8e4a6a73e`, bundled in xllamacpp 2026.9.10809.
+It follows the narrowed position-based guard in
+[upstream PR #28587](https://github.com/ggml-org/llama.cpp/pull/28587), revision
+`4dc1fc0bd42beb28f71bc6531a11f1486cc1152f`. That PR is still under discussion,
+not an accepted upstream fix; this is a temporary, locally validated hotfix.
+
+M-RoPE image rows share a section-0 position. Injecting thousands of those rows
+into the drafter's 2048-position sliding-window cache can exhaust its cells
+before any become eligible for eviction. This fails even with free GPU memory.
+The patch skips only those pinned-position **draft** embedding injections.
+The target model still receives all image rows and verifies the proposed output.
+Advancing audio/text embeddings are not skipped. Draft acceptance after images
+can differ; this does not expand the target context or change target KV precision,
+sampling parameters, model weights, or image resolution.
+
+The CUDA Docker image builds the patched binding for SM86, SM89 and SM120.
+Other images still install upstream wheels; native/other-backend users can build
+the same fix with `python scripts/build_xllamacpp.py --install` (add `--cuda` or
+`--hip` as appropriate). CMake, a compiler, Rust/cargo and the backend SDK are
+required. Builds default to 20 jobs; use `--jobs` to reduce this on small hosts.
+The installed marker `xllamacpp._ezlocalai_hotfix.HOTFIX` identifies patched wheels.
+Reinstalling the official wheel removes the fix.
+
+Remove this patch/source-build override once an upstream xllamacpp release
+contains a verified fix. Re-run the large-image regression suite before updating
+the pin: a small single image is insufficient to catch the cache exhaustion.

--- a/native/patches/dflash-pinned-image-positions.patch
+++ b/native/patches/dflash-pinned-image-positions.patch
@@ -1,0 +1,31 @@
+diff --git a/common/speculative.cpp b/common/speculative.cpp
+--- a/common/speculative.cpp
++++ b/common/speculative.cpp
+@@ -1094,8 +1094,8 @@ struct common_speculative_impl_draft_dflash : public common_speculative_impl {
+ 
+         // Target prefill may contain token IDs or multimodal embeddings. Both
+         // produce the target-layer features used to seed the draft KV cache, so
+-        // skipping the embedding batches leaves a hole in the draft's cache and
+-        // the next injection fails to initialize.
++        // inject embeddings as well, except for pinned-position image batches
++        // that would exhaust the draft's sliding-window cache (see below).
+         // TODO: revisit after https://github.com/ggml-org/llama.cpp/pull/24669 is merged
+         const bool has_tokens     = batch_in.token != nullptr;
+         const bool has_embeddings = batch_in.embd  != nullptr;
+@@ -1131,6 +1131,16 @@ struct common_speculative_impl_draft_dflash : public common_speculative_impl {
+             }
+             const int32_t n_rows = i_batch_end[seq_id] - i_batch_beg[seq_id] + 1;
+ 
++            // M-RoPE images pin section-0 positions. Their rows cannot be
++            // evicted from the draft's sliding-window cache until the position
++            // advances, so one image can exhaust that cache. Skip only these
++            // draft injections; the target still processes the complete image
++            // and verifies all proposals. Advancing audio/text rows are kept.
++            const bool pos_pinned = batch_in.pos[i_batch_beg[seq_id]] == batch_in.pos[i_batch_end[seq_id]];
++            if (has_embeddings && n_rows > 1 && pos_pinned) {
++                continue;
++            }
++
+             for (int32_t offset = 0; offset < n_rows; offset += n_ubatch) {
+                 const int32_t n_chunk = std::min(n_ubatch, n_rows - offset);
+ 

--- a/scripts/build_xllamacpp.py
+++ b/scripts/build_xllamacpp.py
@@ -67,6 +67,15 @@ def prepare_source(source):
     )
 
 
+def invalidate_extension(source):
+    # setuptools does not track updated extra_objects (the native static libs)
+    # when deciding whether to relink. Remove only generated binding binaries;
+    # keep every object/library so cached source builds remain incremental.
+    for suffix in ("so", "pyd"):
+        for binary in (source / "build").glob(f"lib*/xllamacpp/xllamacpp*.{suffix}"):
+            binary.unlink()
+
+
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
     backend = parser.add_mutually_exclusive_group()
@@ -86,6 +95,7 @@ def main():
     )
     wheels = Path(args.wheel_dir).resolve() if args.wheel_dir else workspace / "wheels"
     prepare_source(source)
+    invalidate_extension(source)
     env = dict(
         os.environ,
         NPROC=str(args.jobs),
@@ -101,6 +111,10 @@ def main():
         env.pop(name, None)
     if args.cuda:
         env.update(XLLAMACPP_BUILD_CUDA="1", CUDA_ARCHITECTURES=args.cuda_architectures)
+        # The binding's linker omits NCCL even when CMake auto-detects it.
+        # Disable that optional multi-GPU collective backend, matching our
+        # single-GPU reference build and avoiding an unimportable extension.
+        env["CMAKE_ARGS"] = env.get("CMAKE_ARGS", "") + " -DGGML_CUDA_NCCL=OFF"
         # setup.py searches CUDA_PATH/lib; NVIDIA Linux installs use lib64.
         cuda = Path(env.get("CUDA_PATH") or env.get("CUDA_HOME") or "/usr/local/cuda")
         env["CUDA_PATH"] = str(cuda)

--- a/scripts/build_xllamacpp.py
+++ b/scripts/build_xllamacpp.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Build the pinned xllamacpp with the DFlash large-image cache hotfix.
+
+Requires CMake, a C/C++ compiler, Rust/cargo, and (for --cuda/--hip) its SDK.
+Example: python scripts/build_xllamacpp.py --cuda --install
+Existing source/build directories are reused only at the exact pinned revision.
+The patch is applied by xllamacpp's own patch-aware build, including its existing
+compatibility patches. No models, target KV precision or sampling are changed.
+"""
+
+import argparse
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+
+XLLAMACPP_REVISION = "c490a681ce9ac3490d74b418fee5515ac5c1343e"
+LLAMA_REVISION = "5266f24da75dc449bd56cbed7addb9c8e4a6a73e"
+HOTFIX = "dflash-pinned-image-positions-v1"
+
+
+def run(command, **kwargs):
+    print(subprocess.list2cmdline([str(x) for x in command]), flush=True)
+    return subprocess.run(command, check=True, **kwargs)
+
+
+def prepare_source(source):
+    if not source.exists():
+        run(
+            [
+                "git",
+                "clone",
+                "--no-checkout",
+                "https://github.com/xorbitsai/xllamacpp.git",
+                str(source),
+            ]
+        )
+        run(["git", "checkout", "--detach", XLLAMACPP_REVISION], cwd=source)
+        run(
+            ["git", "submodule", "update", "--init", "--recursive", "--depth", "1"],
+            cwd=source,
+        )
+    for path, expected in (
+        (source, XLLAMACPP_REVISION),
+        (source / "thirdparty/llama.cpp", LLAMA_REVISION),
+    ):
+        actual = run(
+            ["git", "rev-parse", "HEAD"], cwd=path, capture_output=True, text=True
+        ).stdout.strip()
+        if actual != expected:
+            raise RuntimeError(
+                f"Refusing to patch {path}: expected {expected}, got {actual}"
+            )
+    patch = (
+        Path(__file__).resolve().parents[1]
+        / "native/patches/dflash-pinned-image-positions.patch"
+    )
+    destination = source / "patches/llama.cpp/0003-dflash-pinned-image-positions.patch"
+    if destination.exists() and destination.read_bytes() != patch.read_bytes():
+        raise RuntimeError(f"Refusing to overwrite a different patch: {destination}")
+    shutil.copyfile(patch, destination)
+    # Inspectable provenance, bundled in the wheel alongside the Python bindings.
+    (source / "src/xllamacpp/_ezlocalai_hotfix.py").write_text(
+        f"HOTFIX = {HOTFIX!r}\nLLAMA_REVISION = {LLAMA_REVISION!r}\n"
+    )
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    backend = parser.add_mutually_exclusive_group()
+    backend.add_argument("--cuda", action="store_true")
+    backend.add_argument("--hip", action="store_true")
+    parser.add_argument("--jobs", type=int, default=20)
+    parser.add_argument("--cuda-architectures", default="86-real;89-real;120-real")
+    parser.add_argument("--source-dir")
+    parser.add_argument("--wheel-dir")
+    parser.add_argument("--install", action="store_true")
+    args = parser.parse_args()
+    if args.jobs < 1:
+        parser.error("--jobs must be positive")
+    workspace = Path(tempfile.mkdtemp(prefix="ezlocalai-xllamacpp-"))
+    source = (
+        Path(args.source_dir).resolve() if args.source_dir else workspace / "source"
+    )
+    wheels = Path(args.wheel_dir).resolve() if args.wheel_dir else workspace / "wheels"
+    prepare_source(source)
+    env = dict(
+        os.environ,
+        NPROC=str(args.jobs),
+        CARGO_BUILD_JOBS=str(args.jobs),
+        CMAKE_BUILD_PARALLEL_LEVEL=str(args.jobs),
+        XLLAMACPP_RELEASE="1",
+    )
+    for name in (
+        "XLLAMACPP_BUILD_CUDA",
+        "XLLAMACPP_BUILD_HIP",
+        "XLLAMACPP_BUILD_VULKAN",
+    ):
+        env.pop(name, None)
+    if args.cuda:
+        env.update(XLLAMACPP_BUILD_CUDA="1", CUDA_ARCHITECTURES=args.cuda_architectures)
+        # setup.py searches CUDA_PATH/lib; NVIDIA Linux installs use lib64.
+        cuda = Path(env.get("CUDA_PATH") or env.get("CUDA_HOME") or "/usr/local/cuda")
+        env["CUDA_PATH"] = str(cuda)
+        library_dirs = [
+            str(cuda / part)
+            for part in ("lib64", "lib64/stubs", "lib", "lib/stubs")
+            if (cuda / part).is_dir()
+        ]
+        env["LIBRARY_PATH"] = os.pathsep.join(
+            library_dirs + [env.get("LIBRARY_PATH", "")]
+        )
+    elif args.hip:
+        env["XLLAMACPP_BUILD_HIP"] = "1"
+    run(
+        [
+            sys.executable,
+            "-m",
+            "pip",
+            "wheel",
+            str(source),
+            "--no-deps",
+            "--wheel-dir",
+            str(wheels),
+        ],
+        env=env,
+    )
+    built = sorted(wheels.glob("xllamacpp-*.whl"), key=lambda p: p.stat().st_mtime)
+    if not built:
+        raise RuntimeError("xllamacpp build produced no wheel")
+    if args.install:
+        run(
+            [
+                sys.executable,
+                "-m",
+                "pip",
+                "install",
+                "--force-reinstall",
+                "--no-deps",
+                str(built[-1]),
+            ]
+        )
+        run(
+            [
+                sys.executable,
+                "-c",
+                f"from xllamacpp._ezlocalai_hotfix import HOTFIX; assert HOTFIX == {HOTFIX!r}; print(HOTFIX)",
+            ]
+        )
+    print(f"Patched wheel: {built[-1]}")
+
+
+if __name__ == "__main__":
+    main()

--- a/test_xllamacpp_hotfix.py
+++ b/test_xllamacpp_hotfix.py
@@ -12,6 +12,19 @@ from ezlocalai.Speculative import dflash_hotfix_status
 
 
 class XllamacppHotfixTests(unittest.TestCase):
+    def test_cached_native_build_forces_relink_without_removing_objects(self):
+        with tempfile.TemporaryDirectory() as directory:
+            source = Path(directory)
+            output = source / "build/lib.linux/xllamacpp"
+            output.mkdir(parents=True)
+            binary = output / "xllamacpp.abi3.so"
+            binary.write_bytes(b"old extension")
+            preserved = output / "other.so"
+            preserved.write_bytes(b"not our generated binding")
+            builder.invalidate_extension(source)
+            self.assertFalse(binary.exists())
+            self.assertTrue(preserved.exists())
+
     def test_official_wheel_is_identified_as_unpatched(self):
         with patch.dict(sys.modules, {"xllamacpp._ezlocalai_hotfix": None}):
             self.assertEqual(dflash_hotfix_status(), "unpatched")

--- a/test_xllamacpp_hotfix.py
+++ b/test_xllamacpp_hotfix.py
@@ -1,0 +1,85 @@
+"""Build/provenance contracts; real GPU regression is in benchmark_vision.py."""
+
+import tempfile
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import patch, Mock
+
+from scripts import build_xllamacpp as builder
+from ezlocalai.Speculative import dflash_hotfix_status
+
+
+class XllamacppHotfixTests(unittest.TestCase):
+    def test_official_wheel_is_identified_as_unpatched(self):
+        with patch.dict(sys.modules, {"xllamacpp._ezlocalai_hotfix": None}):
+            self.assertEqual(dflash_hotfix_status(), "unpatched")
+
+    def test_patched_wheel_reports_its_marker(self):
+        module = types.ModuleType("xllamacpp._ezlocalai_hotfix")
+        module.HOTFIX = builder.HOTFIX
+        with patch.dict(sys.modules, {module.__name__: module}):
+            self.assertEqual(dflash_hotfix_status(), builder.HOTFIX)
+
+    def test_cuda_build_includes_patch_and_all_three_gpu_families(self):
+        docker = Path("cuda.Dockerfile").read_text()
+        self.assertIn("native/patches", docker)
+        self.assertIn("build_xllamacpp.py --cuda --install", docker)
+        self.assertIn("86-real;89-real;120-real", docker)
+        self.assertIn("ARG XLLAMACPP_BUILD_JOBS=20", docker)
+
+    def test_unknown_source_revision_is_rejected_without_patching(self):
+        with tempfile.TemporaryDirectory() as directory:
+            with patch.object(builder, "run", return_value=Mock(stdout="wrong-sha\n")):
+                with self.assertRaisesRegex(RuntimeError, "Refusing to patch"):
+                    builder.prepare_source(Path(directory))
+            self.assertEqual(list(Path(directory).iterdir()), [])
+
+    def test_pinned_source_gets_patch_and_provenance_marker(self):
+        with tempfile.TemporaryDirectory() as directory:
+            source = Path(directory)
+            (source / "patches/llama.cpp").mkdir(parents=True)
+            (source / "src/xllamacpp").mkdir(parents=True)
+            with patch.object(
+                builder,
+                "run",
+                side_effect=[
+                    Mock(stdout=builder.XLLAMACPP_REVISION),
+                    Mock(stdout=builder.LLAMA_REVISION),
+                ],
+            ):
+                builder.prepare_source(source)
+            self.assertIn(
+                builder.HOTFIX,
+                (source / "src/xllamacpp/_ezlocalai_hotfix.py").read_text(),
+            )
+            content = (
+                source / "patches/llama.cpp/0003-dflash-pinned-image-positions.patch"
+            ).read_text()
+            self.assertIn("has_embeddings && n_rows > 1 && pos_pinned", content)
+            self.assertNotIn("n_rows > 1 && is_mrope", content)
+
+    def test_conflicting_patch_is_not_overwritten(self):
+        with tempfile.TemporaryDirectory() as directory:
+            source = Path(directory)
+            location = (
+                source / "patches/llama.cpp/0003-dflash-pinned-image-positions.patch"
+            )
+            location.parent.mkdir(parents=True)
+            location.write_text("user changes")
+            with patch.object(
+                builder,
+                "run",
+                side_effect=[
+                    Mock(stdout=builder.XLLAMACPP_REVISION),
+                    Mock(stdout=builder.LLAMA_REVISION),
+                ],
+            ):
+                with self.assertRaisesRegex(RuntimeError, "Refusing to overwrite"):
+                    builder.prepare_source(source)
+            self.assertEqual(location.read_text(), "user changes")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fix the post-deployment `failed to process mtmd chunk` failures on DFlash vision requests. The router was reporting 61 failures across the 3090/4090 workers; local logs traced them to pinned image positions exhausting the drafter's sliding-window cache.

- Build the CUDA image's xllamacpp from exact pinned source plus a narrowly scoped native patch, for SM86/89/120 with 20 build jobs and cached intermediates.
- Keep the target's complete image input, model/KV precision, sampling and DFlash settings unchanged. Skip only pinned-position image embedding injection in the drafter, not advancing audio/text embeddings.
- Bundle an inspectable hotfix marker and log its presence at LLM startup; warn on unpatched vision builds.
- Add reproducible large-image/OCR/cache/streaming regression tests and build/provenance unit tests.
- Disable the optional NCCL collective backend, which this xllamacpp revision's binding linker omits even when CMake auto-detects it. Single-GPU CUDA offload remains enabled. Force relinking on cached native builds so updated static libraries cannot leave a stale Python extension.

The native guard follows the latest narrowed form of ggml-org/llama.cpp#28587. That PR remains disputed/unmerged; this is a temporary, locally tested hotfix, not a claim of upstream acceptance. Full draft-cache allocation was also tested and rejected because it OOMed on a 24 GB card.

## Validation

- Official wheel reproduced the failure on three large-image/text-prefix cases; the small-image smoke test passed.
- Target-only visual reference: 20/20 checks passed.
- Patched DFlash through Python bindings: 20/20 checks passed, including OCR, multiple images, long text before/after images, cached repeats, 512-token image-conditioned generation and text after vision.
- Text control: identical 256-token greedy output and draft acceptance (174/242) before/after. Short timings under concurrent build load are documented, not treated as a speed comparison.
- Python unit suite: 278 cases, 277 passed and one intentional skip. Black and diff whitespace checks pass.
- CUDA Docker rebuild/restart completed successfully. The actual rebuilt worker passed 10/10 live HTTP SSE checks, including large images, OCR, cache reuse and sustained image-conditioned generation. Every stream reached `[DONE]` without an error event.
- Runtime import and startup log confirm `dflash-pinned-image-positions-v1`. Health returns 200; no decode/CUDA errors in validation logs. The router sees `DevXT3090J` at commit `59c1597`, zero errors, and the original 220,000 context allocation.

See `benchmarks/dflash-vision-regression-20260908.md` and `native/patches/README.md` for limitations and reproduction commands. Only the local RTX 3090 Ti is physically tested. Remote workers still need this CUDA image deployed. Other Docker backends retain their upstream wheel; the standalone build script supports backend-specific builds.
