### PR TITLE
perf: reuse system-prefix cache affinity across new conversations

### DIFF
--- a/ROUTER.md
+++ b/ROUTER.md
@@ -70,6 +70,29 @@ Then run the router server
 docker compose -f docker-compose-router.yml pull && docker compose -f docker-compose-router.yml up -d
 ```
 
+## Reusing Prompt Prefixes
+
+Chat requests with a long leading system message can reuse routing affinity
+across new conversations. The router hashes exact system-text prefixes in
+16,384-character blocks (up to 524,288 characters); it stores only digests and
+worker IDs, never copies of the prompt. A conversation-specific suffix does
+not invalidate earlier matching blocks. Messages and generation settings are
+forwarded unchanged.
+
+An existing `prompt_cache_key` owner takes precedence. Without an eligible
+owner, the longest matching system prefix can select an idle compatible local
+worker, provided its hardware tier is at least as high as the fastest available
+compatible worker. This fallback never waits, selects a paid overflow worker,
+or overrides nested browser requests' parent-cache exclusions. Separate bounded
+hint storage uses the same `ROUTER_PROMPT_AFFINITY_TTL` and
+`ROUTER_PROMPT_AFFINITY_MAX` limits as conversation affinity.
+
+The `shared system-prefix affinity` log records a routing hint, **not a measured
+cache hit**. Worker restarts, model unloads, or KV eviction can still cause a
+miss. A genuinely cold system prompt still requires full prefill; compare the
+worker-reported cached tokens and TTFT across fresh conversations to measure
+the benefit on your workload.
+
 ## Connecting ezLocalai Workers
 
 Edit the `.env` of the ezLocalai worker to connect it to your ezLocalai router.

--- a/router_app.py
+++ b/router_app.py
@@ -37,6 +37,7 @@ OpenAI-compatible (proxied)
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import html
 import json
 import logging
@@ -112,6 +113,7 @@ app.mount("/outputs", StaticFiles(directory=_OUTPUTS_DIR), name="outputs")
 # model and capability are part of the lookup so lightweight control-model
 # calls cannot displace the main conversation model's affinity.
 _prompt_affinity: Dict[str, tuple[str, float]] = {}
+_system_prefix_affinity: Dict[str, tuple[str, float]] = {}
 
 
 CHUTES_WORKER_ID = "external-chutes"
@@ -3139,16 +3141,74 @@ def _prompt_affinity_key(
     return f"{capability}:{_normalize_model_name(model)}:{raw.strip()[:512]}"
 
 
+def _system_prefix_affinity_keys(
+    payload: Dict[str, Any], capability: str, model: Optional[str]
+) -> List[str]:
+    """Opaque hints for cold conversations, not a claim that KV is still resident.
+
+    Hash exact leading system text in incremental blocks so a conversation-
+    specific suffix doesn't discard an otherwise reusable tool/system prefix.
+    Never hash later messages: those don't establish a shared leading prefix.
+    """
+    messages = payload.get("messages")
+    if capability != "text" or not isinstance(messages, list) or not messages:
+        return []
+    first = messages[0]
+    if not isinstance(first, dict) or first.get("role") != "system":
+        return []
+    content = first.get("content")
+    if not isinstance(content, str):
+        return []
+    block = 16384
+    limit = min(len(content), 524288)
+    # Native tools/template flags can change tokens preceding the system text.
+    # Keep those lanes separate even if the visible system content is equal.
+    template = {
+        key: payload[key]
+        for key in (
+            "tools",
+            "tool_choice",
+            "functions",
+            "function_call",
+            "chat_template",
+            "chat_template_kwargs",
+        )
+        if key in payload
+    }
+    template["system_metadata"] = {k: v for k, v in first.items() if k != "content"}
+    digest = hashlib.sha256(json.dumps(template, ensure_ascii=False).encode("utf-8"))
+    keys = []
+    for start in range(0, limit, block):
+        end = min(start + block, limit)
+        digest.update(content[start:end].encode("utf-8"))
+        if end >= block:
+            keys.append(
+                f"system-prefix:{capability}:{_normalize_model_name(model)}:"
+                f"{end}:{digest.hexdigest()}"
+            )
+    return keys
+
+
+def _remember_system_prefixes(keys: Optional[List[str]], worker: WorkerInfo) -> None:
+    if worker.external_fallback:
+        return
+    now = time.time()
+    for key in keys or ():
+        _system_prefix_affinity[key] = (worker.worker_id, now)
+
+
 def _prune_prompt_affinity(now: float) -> None:
     ttl = max(60.0, _float_env("ROUTER_PROMPT_AFFINITY_TTL", 3600.0))
-    expired = [key for key, (_, seen) in _prompt_affinity.items() if now - seen > ttl]
-    for key in expired:
-        _prompt_affinity.pop(key, None)
     max_entries = max(100, int(_float_env("ROUTER_PROMPT_AFFINITY_MAX", 10000)))
-    if len(_prompt_affinity) > max_entries:
-        oldest = sorted(_prompt_affinity.items(), key=lambda item: item[1][1])
-        for key, _ in oldest[: len(_prompt_affinity) - max_entries]:
-            _prompt_affinity.pop(key, None)
+    # Prefix hints must not evict existing conversations' cache-home mappings.
+    for entries in (_prompt_affinity, _system_prefix_affinity):
+        expired = [key for key, (_, seen) in entries.items() if now - seen > ttl]
+        for key in expired:
+            entries.pop(key, None)
+        if len(entries) > max_entries:
+            oldest = sorted(entries.items(), key=lambda item: item[1][1])
+            for key, _ in oldest[: len(entries) - max_entries]:
+                entries.pop(key, None)
 
 
 def _prompt_affinity_wait_timeout() -> float:
@@ -3252,6 +3312,7 @@ async def _pick(
     external_fallback_allowed: bool = True,
     wait_indefinitely: bool = False,
     affinity_key: Optional[str] = None,
+    system_prefix_keys: Optional[List[str]] = None,
 ) -> WorkerInfo:
     router = get_router()
     # Pre-exclude tunneled workers whose WebSocket is not currently connected.
@@ -3300,6 +3361,7 @@ async def _pick(
                 break
             if preferred.has_capacity(capability, model):
                 _prompt_affinity[affinity_key] = (preferred.worker_id, time.time())
+                _remember_system_prefixes(system_prefix_keys, preferred)
                 logging.info(
                     f"[Router] prompt-cache affinity -> {preferred.label} "
                     f"(model={model!r}, cap={capability})"
@@ -3314,6 +3376,32 @@ async def _pick(
                 )
                 break
             await asyncio.sleep(min(0.1, remaining))
+    # Cold conversations may reuse another conversation's stable prefix. This
+    # fallback never waits or overrides a still-eligible conversation owner.
+    if system_prefix_keys and not preferred_is_eligible:
+        workers = {w.worker_id: w for w in registry.list_workers(alive_only=True)}
+        idle_workers = {
+            wid: w
+            for wid, w in workers.items()
+            if _eligible_affinity_worker(w, capability, model, pre_exclude)
+            and w.has_capacity(capability, model)
+            and w.effective_busy(capability=capability, model=model) == 0
+        }
+        fastest_tier = max((w.best_tier for w in idle_workers.values()), default=0)
+        for key in reversed(system_prefix_keys or ()):
+            candidate_id = _system_prefix_affinity.get(key, (None, 0.0))[0]
+            candidate = idle_workers.get(candidate_id)
+            if candidate is not None and candidate.best_tier >= fastest_tier:
+                if affinity_key:
+                    _prompt_affinity[affinity_key] = (candidate.worker_id, time.time())
+                _remember_system_prefixes(system_prefix_keys, candidate)
+                logging.info(
+                    "[Router] shared system-prefix affinity -> %s (model=%r, cap=%s)",
+                    candidate.label,
+                    model,
+                    capability,
+                )
+                return candidate
     worker = await router.wait_for_worker(
         capability,
         model,
@@ -3334,6 +3422,7 @@ async def _pick(
         and (not preferred_is_eligible or worker.worker_id == preferred_id)
     ):
         _prompt_affinity[affinity_key] = (worker.worker_id, time.time())
+    _remember_system_prefixes(system_prefix_keys, worker)
     return worker
 
 
@@ -4063,6 +4152,7 @@ async def _llm_stream_with_worker_failover(
 ) -> AsyncIterator[bytes]:
     tried: set = set()
     affinity_key = _prompt_affinity_key(payload, capability, model)
+    system_prefix_keys = _system_prefix_affinity_keys(payload, capability, model)
     cache_avoid_worker_ids = _prompt_cache_avoid_worker_ids(
         payload, capability, model, tried
     )
@@ -4080,6 +4170,7 @@ async def _llm_stream_with_worker_failover(
                 external_fallback_allowed=external_fallback_allowed,
                 wait_indefinitely=wait_indefinitely,
                 affinity_key=affinity_key,
+                system_prefix_keys=system_prefix_keys,
             )
         except Exception as e:
             last_error = f"{type(e).__name__}: {e}"
@@ -4848,6 +4939,7 @@ async def _llm_proxy_with_retry(
 
     tried: set = set()
     affinity_key = _prompt_affinity_key(payload, capability, model)
+    system_prefix_keys = _system_prefix_affinity_keys(payload, capability, model)
     cache_avoid_worker_ids = _prompt_cache_avoid_worker_ids(
         payload, capability, model, tried
     )
@@ -4863,6 +4955,7 @@ async def _llm_proxy_with_retry(
             external_fallback_allowed=external_fallback_allowed,
             wait_indefinitely=wait_indefinitely,
             affinity_key=affinity_key,
+            system_prefix_keys=system_prefix_keys,
         )
         reservation_id = get_registry().try_reserve_in_flight(
             worker.worker_id,

--- a/test_router_prefix_affinity.py
+++ b/test_router_prefix_affinity.py
@@ -1,0 +1,253 @@
+"""Routing-only tests: no model, credentials, or GPU needed."""
+
+import copy
+import time
+import unittest
+from unittest.mock import AsyncMock, patch
+
+from Router import WorkerInfo, WorkerRegistry
+import router_app
+
+
+def keys(text, model="model"):
+    return router_app._system_prefix_affinity_keys(
+        {"messages": [{"role": "system", "content": text}]}, "text", model
+    )
+
+
+class SystemPrefixTests(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.affinity_patch = patch.dict(router_app._prompt_affinity, {}, clear=True)
+        self.affinity_patch.start()
+        self.addCleanup(self.affinity_patch.stop)
+        prefix_patch = patch.dict(router_app._system_prefix_affinity, {}, clear=True)
+        prefix_patch.start()
+        self.addCleanup(prefix_patch.stop)
+        self.registry = WorkerRegistry(ttl_seconds=60)
+        self.workers = []
+        for name in ["short", "long", "cold"]:
+            self.workers.append(
+                self.registry.register(
+                    WorkerInfo(
+                        worker_id=name,
+                        label=name,
+                        url=f"http://{name}",
+                        capabilities=["text"],
+                        models=["model"],
+                    )
+                )
+            )
+        self.router = type(
+            "Router", (), {"wait_for_worker": AsyncMock(return_value=self.workers[2])}
+        )()
+        for target, value in [
+            ("get_registry", self.registry),
+            ("get_router", self.router),
+        ]:
+            p = patch(f"router_app.{target}", return_value=value)
+            p.start()
+            self.addCleanup(p.stop)
+        self.prefix = keys("a" * 16384 + "b" * 16384 + "conversation-specific suffix")
+
+    def remember(self, prefix, worker):
+        entries = (
+            router_app._system_prefix_affinity
+            if prefix in self.prefix
+            else router_app._prompt_affinity
+        )
+        entries[prefix] = (worker.worker_id, time.time())
+
+    def test_exact_incremental_prefix_preserves_suffix_independence(self):
+        other = keys("a" * 16384 + "b" * 16384 + "different suffix")
+        self.assertEqual(self.prefix[:2], other[:2])
+        self.assertNotEqual(self.prefix[-1], other[-1])
+        self.assertNotEqual(self.prefix[0], keys("A" + "a" * 16383)[0])
+        self.assertNotEqual(self.prefix[0], keys("a" * 16384, "other-model")[0])
+
+    def test_bounded_hashes_do_not_retain_prompt_or_modify_payload(self):
+        payload = {
+            "messages": [
+                {"role": "system", "content": "secret-value " * 100000},
+                {"role": "user", "content": "user input"},
+            ]
+        }
+        before = copy.deepcopy(payload)
+        result = router_app._system_prefix_affinity_keys(payload, "text", "model")
+        self.assertEqual(len(result), 32)
+        self.assertFalse(any("secret-value" in key for key in result))
+        self.assertEqual(payload, before)
+
+    def test_native_tools_and_template_settings_use_separate_cache_lanes(self):
+        payload = {"messages": [{"role": "system", "content": "x" * 20000}]}
+        baseline = router_app._system_prefix_affinity_keys(payload, "text", "model")
+        for field, value in [
+            ("tools", [{"type": "function", "function": {"name": "tool"}}]),
+            ("chat_template_kwargs", {"enable_thinking": True}),
+            ("chat_template", "custom"),
+        ]:
+            self.assertNotEqual(
+                baseline,
+                router_app._system_prefix_affinity_keys(
+                    {**payload, field: value}, "text", "model"
+                ),
+            )
+
+    def test_only_large_leading_text_system_messages_qualify(self):
+        for messages in [
+            None,
+            [],
+            "invalid",
+            [None],
+            [{"role": "user", "content": "x" * 20000}],
+            [{"role": "system", "content": [{"type": "text", "text": "x" * 20000}]}],
+            [{"role": "system", "content": "short"}],
+        ]:
+            self.assertEqual(
+                router_app._system_prefix_affinity_keys(
+                    {"messages": messages}, "text", "model"
+                ),
+                [],
+            )
+        self.assertEqual(
+            router_app._system_prefix_affinity_keys(
+                {"messages": [{"role": "system", "content": "x" * 20000}]},
+                "tts",
+                "model",
+            ),
+            [],
+        )
+
+    async def test_new_conversation_prefers_longest_matching_idle_prefix(self):
+        self.remember(self.prefix[0], self.workers[0])
+        self.remember(self.prefix[1], self.workers[1])
+        worker = await router_app._pick(
+            "text", "model", affinity_key="new", system_prefix_keys=self.prefix
+        )
+        self.assertEqual(worker.worker_id, "long")
+        self.assertEqual(router_app._prompt_affinity["new"][0], "long")
+        self.router.wait_for_worker.assert_not_awaited()
+
+    async def test_busy_long_prefix_uses_idle_shorter_prefix_without_waiting(self):
+        self.remember(self.prefix[0], self.workers[0])
+        self.remember(self.prefix[1], self.workers[1])
+        self.workers[1].queue_depth = 1
+        with patch("router_app.asyncio.sleep", new_callable=AsyncMock) as sleep:
+            worker = await router_app._pick(
+                "text", "model", system_prefix_keys=self.prefix
+            )
+            sleep.assert_not_awaited()
+        self.assertEqual(worker.worker_id, "short")
+
+    async def test_busy_prefix_falls_back_to_normal_selector(self):
+        self.remember(self.prefix[0], self.workers[0])
+        self.workers[0].queue_depth = 1
+        worker = await router_app._pick("text", "model", system_prefix_keys=self.prefix)
+        self.assertEqual(worker.worker_id, "cold")
+        self.router.wait_for_worker.assert_awaited_once()
+
+    async def test_partial_prefix_does_not_downgrade_to_slower_hardware(self):
+        self.remember(self.prefix[0], self.workers[0])
+        self.workers[0].best_tier = 60
+        self.workers[2].best_tier = 90
+        worker = await router_app._pick("text", "model", system_prefix_keys=self.prefix)
+        self.assertEqual(worker.worker_id, "cold")
+
+    async def test_existing_conversation_owner_wins(self):
+        self.remember("existing", self.workers[0])
+        self.remember(self.prefix[-1], self.workers[1])
+        worker = await router_app._pick(
+            "text", "model", affinity_key="existing", system_prefix_keys=self.prefix
+        )
+        self.assertEqual(worker.worker_id, "short")
+
+    async def test_busy_conversation_spills_normally_without_moving_home(self):
+        self.remember("existing", self.workers[0])
+        self.workers[0].queue_depth = 1
+        self.remember(self.prefix[-1], self.workers[1])
+        with patch("router_app._prompt_affinity_wait_timeout", return_value=0):
+            worker = await router_app._pick(
+                "text", "model", affinity_key="existing", system_prefix_keys=self.prefix
+            )
+        self.assertEqual(worker.worker_id, "cold")
+        self.assertEqual(router_app._prompt_affinity["existing"][0], "short")
+
+    async def test_excluded_parent_cache_worker_is_not_selected(self):
+        self.remember(self.prefix[-1], self.workers[0])
+        worker = await router_app._pick(
+            "text", "model", exclude={"short"}, system_prefix_keys=self.prefix
+        )
+        self.assertEqual(worker.worker_id, "cold")
+
+    async def test_stale_and_incompatible_prefixes_are_not_selected(self):
+        router_app._system_prefix_affinity[self.prefix[0]] = ("short", 0)
+        self.remember(self.prefix[-1], self.workers[1])
+        self.workers[1].models = ["unrelated"]
+        worker = await router_app._pick("text", "model", system_prefix_keys=self.prefix)
+        self.assertEqual(worker.worker_id, "cold")
+
+    def test_external_fallback_never_owns_system_prefix(self):
+        self.workers[0].external_fallback = True
+        router_app._remember_system_prefixes(self.prefix, self.workers[0])
+        self.assertFalse(router_app._prompt_affinity)
+        self.assertFalse(router_app._system_prefix_affinity)
+
+    def test_prefix_hint_volume_does_not_evict_conversation_home(self):
+        self.remember("existing", self.workers[0])
+        for i in range(110):
+            router_app._system_prefix_affinity[str(i)] = ("short", time.time())
+        with patch.dict(router_app.os.environ, {"ROUTER_PROMPT_AFFINITY_MAX": "100"}):
+            router_app._prune_prompt_affinity(time.time())
+        self.assertEqual(len(router_app._system_prefix_affinity), 100)
+        self.assertIn("existing", router_app._prompt_affinity)
+
+    async def test_streaming_and_nonstreaming_requests_use_identical_prefix_hints(self):
+        payload = {
+            "model": "model",
+            "temperature": 0.7,
+            "messages": [
+                {"role": "system", "content": "stable instructions " * 2000},
+                {"role": "user", "content": "Do the task"},
+            ],
+            "prompt_cache_key": "fresh-conversation",
+        }
+        before = copy.deepcopy(payload)
+        expected = router_app._system_prefix_affinity_keys(payload, "text", "model")
+
+        async def fake_stream(worker, path, forwarded, **kwargs):
+            self.assertEqual(forwarded, before)
+            yield b'data: {"choices":[{"delta":{"content":"ok"}}]}\n\n'
+            yield b'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n\n'
+
+        for streaming in [False, True]:
+            with self.subTest(streaming=streaming), patch(
+                "router_app._pick", new_callable=AsyncMock, return_value=self.workers[0]
+            ) as pick, patch(
+                "router_app._proxy_json",
+                new_callable=AsyncMock,
+                return_value=router_app.JSONResponse({"choices": []}),
+            ) as proxy, patch(
+                "router_app._iter_worker_stream_bytes", fake_stream
+            ), patch(
+                "router_app._record_llm_usage", new_callable=AsyncMock
+            ):
+                response = await router_app._llm_proxy_with_retry(
+                    capability="text",
+                    path="/v1/chat/completions",
+                    payload=payload,
+                    model="model",
+                    is_stream=streaming,
+                )
+                if streaming:
+                    chunks = [chunk async for chunk in response.body_iterator]
+                    self.assertTrue(any(b"ok" in chunk for chunk in chunks))
+                else:
+                    self.assertEqual(proxy.call_args.args[2], before)
+                self.assertEqual(pick.call_args.kwargs["system_prefix_keys"], expected)
+                self.assertEqual(payload, before)
+                # Fake transports don't perform their production cleanup.
+                self.workers[0].router_reservations.clear()
+                self.workers[0]._refresh_router_reservations()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Reduce repeated first-turn prefill by reusing routing hints for stable system prefixes across new conversations. Companion to https://github.com/Josh-XT/WorkConductor/pull/232.

- Hash exact leading system text incrementally, allowing a varying conversation suffix without invalidating the common prefix. Keep native tool/template settings in separate lanes.
- Existing conversation cache ownership wins. Cold conversations can prefer the longest matching idle local worker only within the fastest available compatible hardware tier.
- Do not wait for a busy prefix owner, override parent/browser exclusions, select external fallback via prefix hints, switch models, prune context, or change generation settings.
- Keep bounded, TTL-pruned digest-only hints separate from conversation affinity so they cannot evict conversation cache homes.
- Apply to streaming and non-streaming chat requests. Logs label routing hints distinctly from measured cache hits.

## Verification
- 143 focused tests passed across prefix routing, streaming, selection, capability retries, Chutes/OpenRouter, and dashboard usage.
- Added 15 tests covering shared prefixes, suffix changes, tools/templates, model boundaries, busy/faster/excluded workers, TTL/bounds, request preservation, and both forwarding paths.
- Black and diff checks pass.
- Local CUDA image rebuilt/restarted and local router restarted; both healthy, no new router runtime errors.
- CPU-only hashing check: about 0.38 ms/request for a 524,288-character system prefix over 1,000 iterations.

## Scope / Rollout
Router deployment is required for the routing improvement; workers do not need a new inference implementation. Local worker was rebuilt per development workflow. No model, context limit, quantization, speculative decoding, or speech setting changes.
No live multi-worker TTFT percentage claim: this is a placement hint, not proof of resident KV. Restarts/unloads/eviction can cause misses. Completely cold prompts still need full prefill. Measure fresh conversations with the same agent/tools using worker-reported cached tokens and TTFT after deploying the router.